### PR TITLE
support empty closing tags </>

### DIFF
--- a/src/CorrectEmptyClosingTag.cs
+++ b/src/CorrectEmptyClosingTag.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FileDBReader
+{
+    class CorrectEmptyClosingTag
+    {
+        private string CurrentTag = "";
+        private bool InOpenTag = false;
+        private Stack<string> TagHistory = new Stack<string>();
+        private string LastChars = "";
+
+        public void Advance(char CurrentChar)
+        {
+            LastChars = ((LastChars.Length >= 3) ? LastChars[1..] : LastChars) + CurrentChar;
+
+            if (CurrentChar == '<')
+            {
+                InOpenTag = true;
+            }
+            else if (CurrentChar == '>' && InOpenTag)
+            {
+                InOpenTag = false;
+                TagHistory.Push(CurrentTag);
+                CurrentTag = "";
+            }
+            else if (CurrentChar == '/')
+            {
+                // cancel open tag
+                InOpenTag = false;
+            }
+            else if (InOpenTag)
+            {
+                CurrentTag += CurrentChar;
+            }
+        }
+
+        public bool IsClosing()
+        {
+            return LastChars.StartsWith("</");
+        }
+
+        public char[] GetCorrection()
+        {
+            // empty closing tag, return replacement
+            if (LastChars.Last() == '>')
+            {
+                return TagHistory.Pop().ToCharArray();
+            }
+            // if non-empty, we still need to pop the stack
+            else
+            {
+                TagHistory.Pop();
+                return Array.Empty<char>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
.rdp files are similar to .fc files, but they don't have proper closing tags but shortened versions </>.

This commit adds correction of those tags when importing. Exporting does not remove them again, but Anno doesn't care.

Unfortunately, that breaks the current way the tests work as well. I left them out for that reason.


A future PR may look at the reverse direction and add an option to the interpreter file or as a command line parameter to restore the closing tag behavior.