### PR TITLE
add rdp format interpreter

### DIFF
--- a/FileFormats/rdp.xml
+++ b/FileFormats/rdp.xml
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+	Interpreter for .rdp files
+	
+	Verified with Anno 1800.
+
+	All positions are relative to <Center> and scaled by <Extents>.
+	<FrameCount> is animation length.
+	<FrameTime> is time in ms per frame.
+	Texture speed is with <MovieFPS>=0 one cycle per longest particle frame count?
+		Otherwise exactly what FPS means ;-)
+-->
+<Converts>
+	<InternalCompression />
+	<Converts>
+		<!--
+			P_ are lists of particle properties.
+			Number of particles is controlled by <ParticleCount>
+		-->
+		<!-- (Particle list) First frame when a particle is shown -->
+		<Convert Path ="//P_Starts" Type ="UInt16" Structure ="List" IsCdataNode ="1"/>
+		<!-- (Particle list) Last frame (inclusive) when a particle is shown -->
+		<Convert Path ="//P_Ends" Type ="UInt16" Structure ="List" IsCdataNode ="1"/>
+		<!-- (Particle list) Material index of particle -->
+		<Convert Path ="//P_Materials" Type ="Byte" Structure ="List" IsCdataNode ="1"/>
+
+		<!--
+			T_ are lists of tick properties.
+			Number of ticks is the sum of (P_Ends - P_Starts) % FrameCount + 1
+		-->
+		<!-- (Tick list) Position x y z with -32767-32767 => -1.0-1.0 * <Extents> -->
+		<Convert Path ="//T_Positions" Type ="Int16" Structure ="List" IsCdataNode ="1"/>
+		<!-- (Tick list) Clockwise rotation x y z with 0-256 => 0-360 degrees -->
+		<!-- y is what you want to rotate with <ViewAligned>=1 -->
+		<Convert Path ="//T_Rotations" Type ="Byte" Structure ="List" IsCdataNode ="1"/>
+		<!-- (Tick list) Scale x y z with 0-255 => 0.0-1.0 * <MaxScale> -->
+		<Convert Path ="//T_Scales" Type ="Byte" Structure ="List" IsCdataNode ="1"/>
+		<!-- (Tick list) Colors in BGRA -->
+		<Convert Path ="//T_Colors" Type ="Byte" Structure ="List" IsCdataNode ="1"/>
+	</Converts>
+</Converts>


### PR DESCRIPTION
I do have some post processing to make the file actually editable.

```xml
  <Particles>
    <Particle>
      <Material>0</Material>
      <StartFrame>140</StartFrame>
      <Ticks>
        <Tick>
          <PositionXYZ>-0.883084 0.709769 -0.057222</PositionXYZ>
          <RotationXYZ>0.0 255.9 0.0</RotationXYZ>
          <ScaleXYZ>1.0000 1.0000 1.0000</ScaleXYZ>
          <ColorARGB>0 255 255 255</ColorARGB>
        </Tick>
        <Tick>
          <PositionXYZ>-0.883084 0.709769 -0.057222</PositionXYZ>
          <RotationXYZ>0.0 255.9 0.0</RotationXYZ>
          <ScaleXYZ>1.0000 1.0000 1.0000</ScaleXYZ>
          <ColorARGB>19 255 255 255</ColorARGB>
        </Tick>
        ...
```

`ParticleCount`, `TotalTickCount` and the contents of `P_Ends` will be calculated. The rest is just reformatting (and changing numbers to their actual ranges).
In the original you had to make sure counts are same as the data.