### PR TITLE
Draft: fix serialization issues

### DIFF
--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
@@ -68,12 +68,18 @@ namespace FileDBSerializing.ObjectSerializer
             //Note: IsPrimitive is the extension method, which does NOT match with the property IsPrimitive!!!!
             if (PropertyType.IsPrimitiveOrString())
             {
+                if (property_instance is null && Options.SkipSimpleNullValues)
+                    return Enumerable.Empty<FileDBNode>();
+
                 //if primitive -> attrib, content to bytes, doneu
                 return new FileDBNode[] { BuildSingleValueAttrib(parentObject, property) };
             }
             //Arrays
             else if (PropertyType.IsArray())
             {
+                if (property_instance is null && Options.SkipSimpleNullValues && PropertyType.IsPrimitiveArray())
+                    return Enumerable.Empty<FileDBNode>();
+
                 return BuildArray(property, parentObject);
             }
             //simple Reference Types should be the only thing here

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBSerializerOptions.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBSerializerOptions.cs
@@ -15,7 +15,7 @@ namespace FileDBSerializing.ObjectSerializer
         public bool IgnoreMissingProperties { get; set; } = false;
 
         public bool SkipDefaultedValues { get; set; } = false;
-
+        public bool SkipSimpleNullValues { get; set; } = true;
 
         public FileDBSerializerOptions()
         {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
@@ -19,7 +19,7 @@ namespace FileDBSerializing.ObjectSerializer
 
         public static bool IsArray(this Type type) => type.IsArray;
 
-        public static bool IsPrimitiveArray(this Type type) => type.IsArray && (type.GetElementType()?.IsPrimitiveType() ?? false);
+        public static bool IsPrimitiveListType(this Type type) => type.IsArray && (type.GetElementType()?.IsPrimitiveType() ?? false);
 
         public static object? GetDefault(this Type type)
         {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
@@ -19,6 +19,8 @@ namespace FileDBSerializing.ObjectSerializer
 
         public static bool IsArray(this Type type) => type.IsArray;
 
+        public static bool IsPrimitiveArray(this Type type) => type.IsArray && (type.GetElementType()?.IsPrimitiveType() ?? false);
+
         public static object? GetDefault(this Type type)
         {
             if (type.IsValueType) return Activator.CreateInstance(type);

--- a/unittests/FileDBReader-Tests/FileDBSerializer/ObjectSerializerTest.cs
+++ b/unittests/FileDBReader-Tests/FileDBSerializer/ObjectSerializerTest.cs
@@ -95,6 +95,41 @@ namespace FileDBSerializing.Tests
             result.Should().BeEquivalentTo(TestDataSources.GetTestAsset());
         }
 
+
+        [TestMethod()]
+        public void SkipSimpleNullValues()
+        {
+            // test default setting
+            FileDBSerializerOptions options = new() { Version = FileDBDocumentVersion.Version1 };
+            Assert.IsTrue(options.SkipSimpleNullValues); 
+            
+            // all null
+            var obj = new RootObject();
+            FileDBDocumentSerializer serializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            IFileDBDocument doc = serializer.WriteObjectStructureToFileDBDocument(obj);
+            XmlDocument xmlDocument = new FileDbXmlConverter().ToXml(doc);
+            Assert.AreEqual("<Content>" +
+                "<DumbManager />" +
+                "<DumbChild />" +
+                "<RefArray />" +
+                "<StringArray />" +
+                "</Content>", xmlDocument.InnerXml);
+
+            // all null, SkipSimpleNullValues = false
+            serializer = new(new() { Version = FileDBDocumentVersion.Version1, SkipSimpleNullValues = false });
+            doc = serializer.WriteObjectStructureToFileDBDocument(obj);
+            xmlDocument = new FileDbXmlConverter().ToXml(doc);
+            Assert.AreEqual("<Content>" +
+                "<RootCount></RootCount>" + // TODO: why are simple null values not self-closing?
+                "<DumbManager />" +
+                "<DumbChild />" +
+                "<PrimitiveArray></PrimitiveArray>" +
+                "<RefArray />" +
+                "<SimpleString></SimpleString>" +
+                "<StringArray />" +
+                "</Content>", xmlDocument.InnerXml);
+        }
+
         private class FlatStringArrayContainer
         {
             [FlatArray]

--- a/unittests/FileDBReader-Tests/FileDBSerializer/ObjectSerializerTest.cs
+++ b/unittests/FileDBReader-Tests/FileDBSerializer/ObjectSerializerTest.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
+using FileDBReader.src.XmlRepresentation;
 using FileDBReader_Tests;
 using FileDBSerializing.ObjectSerializer;
 using FileDBSerializing.Tests.TestData;
@@ -91,6 +93,89 @@ namespace FileDBSerializing.Tests
             RootObject? result = FileDBConvert.DeserializeObject<RootObject>(source, new() { Version = FileDBDocumentVersion.Version2 });
 
             result.Should().BeEquivalentTo(TestDataSources.GetTestAsset());
+        }
+
+        private class FlatStringArrayContainer
+        {
+            [FlatArray]
+            public string[]? Item { get; set; }
+        }
+
+        [TestMethod()]
+        public void DeSerializeFlatStringArrayNull()
+        {
+            static Stream stream(string x) => new MemoryStream(Encoding.Unicode.GetBytes(x));
+
+            // load from XML
+            XmlDocument xmlDocument = new();
+            xmlDocument.Load(stream("<Content></Content>"));
+            IFileDBDocument doc = new XmlFileDbConverter<FileDBDocument_V1>().ToFileDb(xmlDocument);
+
+            // serialize & deserialize
+            FileDBDocumentDeserializer<FlatStringArrayContainer> deserializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            var obj = deserializer.GetObjectStructureFromFileDBDocument(doc);
+
+            Assert.IsNotNull(obj);
+            Assert.IsNull(obj.Item);
+
+            FileDBDocumentSerializer serializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            doc = serializer.WriteObjectStructureToFileDBDocument(obj);
+
+            // convert back to xml
+            xmlDocument = new FileDbXmlConverter().ToXml(doc);
+            Assert.AreEqual("<Content />", xmlDocument.InnerXml);
+        }
+
+        [TestMethod()]
+        public void DeSerializeFlatStringArray()
+        {
+            static Stream stream(string x) => new MemoryStream(Encoding.Unicode.GetBytes(x));
+
+            const string testInput = "<Content>" +
+                "<Item>a</Item>" +
+                "<Item>b</Item>" +
+                "<Item>c</Item>" +
+                "</Content>";
+
+            // load from XML
+            XmlDocument xmlDocument = new();
+            xmlDocument.Load(stream(testInput));
+
+            XmlDocument interpreterDocument = new();
+            interpreterDocument.Load(stream("<Converts><Converts>" +
+                "<Convert Path=\"//Item\" Type=\"String\" Encoding=\"UTF-8\"/>" +
+                "</Converts></Converts>"));
+            XmlDocument xmlWithBytes = new FileDBReader.XmlExporter().Export(xmlDocument, new(interpreterDocument));
+            IFileDBDocument doc = new XmlFileDbConverter<FileDBDocument_V1>().ToFileDb(xmlWithBytes);
+
+            Assert.AreEqual(3, doc.Roots.Count);
+            Assert.IsTrue(doc.Roots[0] is Attrib);
+            Assert.AreEqual("Item", doc.Roots[0].Name);
+
+            Assert.IsTrue(doc.Tags.Attribs.ContainsValue("Item"));  // make sure "Item" is only added as Attrib
+            Assert.IsTrue(!doc.Tags.Tags.ContainsValue("Item"));
+
+            // deserialize & serialize
+            FileDBDocumentDeserializer<FlatStringArrayContainer> deserializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            var obj = deserializer.GetObjectStructureFromFileDBDocument(doc);
+
+            Assert.IsNotNull(obj);
+            Assert.IsNotNull(obj.Item);
+            Assert.AreEqual(3, obj.Item!.Length);
+            Assert.AreEqual("a", obj.Item[0]);
+            Assert.AreEqual("b", obj.Item[1]);
+            Assert.AreEqual("c", obj.Item[2]);
+
+            FileDBDocumentSerializer serializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            doc = serializer.WriteObjectStructureToFileDBDocument(obj);
+
+            Assert.IsTrue(doc.Tags.Attribs.ContainsValue("Item"));  // make sure "Item" is only added as Attrib
+            Assert.IsTrue(!doc.Tags.Tags.ContainsValue("Item"));
+
+            // convert back to xml
+            xmlWithBytes = new FileDbXmlConverter().ToXml(doc);
+            xmlDocument = new FileDBReader.XmlInterpreter().Interpret(xmlWithBytes, new(interpreterDocument));
+            Assert.AreEqual(testInput, xmlDocument.InnerXml);
         }
     }
 }

--- a/unittests/FileDBReader-Tests/TestSerializationData/RootObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/RootObject.cs
@@ -11,24 +11,24 @@ namespace FileDBSerializing.Tests.TestData
 {
     public record RootObject
     {
-        public int RootCount { get; set; }
-        public SomethingManager DumbManager { get; set; }
-        public ChildElement DumbChild { get; set; }
-        public int[] PrimitiveArray { get; set; }
-        public ChildElement[] RefArray { get; set; }
-        public UnicodeString SimpleString { get; set; }
-        public String[] StringArray { get; set; }
+        public int? RootCount { get; set; }
+        public SomethingManager? DumbManager { get; set; }
+        public ChildElement? DumbChild { get; set; }
+        public int[]? PrimitiveArray { get; set; }
+        public ChildElement[]? RefArray { get; set; }
+        public UnicodeString? SimpleString { get; set; }
+        public string[]? StringArray { get; set; }
     }
 
     public record SomethingManager
     {
-        public int SomethingCount { get; set; }
-        public float SomethingValue { get; set; }
-        public ChildElement Child { get; set; }
+        public int? SomethingCount { get; set; }
+        public float? SomethingValue { get; set; }
+        public ChildElement? Child { get; set; }
     }
 
     public record ChildElement
     {
-        public uint ID { get; set; }
+        public uint? ID { get; set; }
     }
 }


### PR DESCRIPTION
- flatarray support for string[]
- don't add empty item for null arrays
- support for primitive list arrays (e.g. byte[][]) 
- add SkipSimpleNullValues (default=true) to align with FileDBReader command line behavior

Note: original unit tests are unchanged. Behavior they covered is unchanged.