### PR TITLE
add polymorph support to deserialization

### DIFF
--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer.cs
@@ -136,7 +136,7 @@ namespace FileDBSerializing.ObjectSerializer
             else if (ArrayContentType.IsPrimitiveListType() /* non-flat primitive lists are Tags */)
                 return BuildPrimitiveListArray(collection, ArrayContentType);
             else
-                return BuildReferenceArray(collection, ArrayContentType);
+                return BuildReferenceArray(collection, ArrayContentType, PropertyInfo.GetCustomAttributes<PolymorphAttribute>());
         }
         #endregion
 
@@ -202,14 +202,18 @@ namespace FileDBSerializing.ObjectSerializer
             );
         }
 
-        private Array BuildReferenceArray(IEnumerable<FileDBNode> Nodes, Type TargetType)
+        private Array BuildReferenceArray(IEnumerable<FileDBNode> Nodes, Type TargetType, IEnumerable<PolymorphAttribute> polymorphAttributes)
         {
             return BuildMultiNodeArray(Nodes, MakeInstance, TargetType);
 
             object MakeInstance(FileDBNode node)
-            {
-                if (node is Attrib) throw new FileDBSerializationException($"Cannot create Array Entry from Attrib: {node.GetName()}");
-                return MakeInstanceFromTag((Tag)node, TargetType);
+            { 
+                if (node is Tag tag)
+                {
+                    Type? polyTarget = polymorphAttributes.FirstOrDefault((x) => x.IsApplicable(tag))?.TargetType;
+                    return MakeInstanceFromTag(tag, polyTarget ?? TargetType);
+                }
+                throw new FileDBSerializationException($"Cannot create Array Entry from Attrib: {node.GetName()}");
             }
         }
         #endregion
@@ -239,7 +243,8 @@ namespace FileDBSerializing.ObjectSerializer
         private void BuildSinglePropertyFromTag(Tag tag, object parentObject, PropertyInfo Property)
         {
             Type PropertyType = Property.GetNullablePropertyType();
-            object PropertyInstance = MakeInstanceFromTag(tag, PropertyType);
+            Type? polyTarget = Property.GetCustomAttributes<PolymorphAttribute>().FirstOrDefault((x) => x.IsApplicable(tag))?.TargetType;
+            object PropertyInstance = MakeInstanceFromTag(tag, polyTarget ?? PropertyType);
             //set the value
             Property.SetValue(parentObject, PropertyInstance);
         }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/PolymorphAttribute.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/PolymorphAttribute.cs
@@ -1,0 +1,43 @@
+﻿using FileDBSerializing.LookUps;
+using System;
+
+namespace FileDBSerializing.ObjectSerializer
+{
+    public enum PolymorphRootNode
+    {
+        Parent,
+        Self
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    public class PolymorphAttribute : Attribute
+    {
+        public Type TargetType { private set; get; }
+        public string Path { private set; get; }
+
+        public PolymorphRootNode Node { set; get; } = PolymorphRootNode.Self;
+        public string? HexValue { set; get; } = null;
+
+        public PolymorphAttribute(Type type, string path)
+        {
+            TargetType = type;
+            Path = path;
+        }
+
+        public bool IsApplicable(Tag tag)
+        {
+            var startNode = Node == PolymorphRootNode.Self ? tag : tag.Parent;
+            var el = startNode.SelectSingleNode(Path);
+            if (el is null)
+                return false;
+
+            // path only check is done
+            if (HexValue is null)
+                return true;
+
+            if (el is Attrib attrib)
+                return HexValue == BitConverter.ToString(attrib.Content).Replace("-", "");
+            return false;
+        }
+    }
+}

--- a/unittests/FileDBReader-Tests/FileDBSerializer/PolymorphSerializerTests.cs
+++ b/unittests/FileDBReader-Tests/FileDBSerializer/PolymorphSerializerTests.cs
@@ -1,0 +1,180 @@
+﻿using System.IO;
+using System.Text;
+using System.Xml;
+using FileDBReader.src.XmlRepresentation;
+using FileDBSerializing;
+using FileDBSerializing.ObjectSerializer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FileDBReader_Tests.FileDBSerializer
+{
+    internal class PolymorphSerializerTests
+    {
+        private class PolymorphOnPathContainer
+        {
+            public class BaseItem
+            {
+            }
+
+            public class ValueItem : BaseItem
+            {
+                [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles")]
+                public Value? value { get; set; }
+            }
+
+            public class Value
+            {
+                [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles")]
+                public int? id { get; set; }
+            }
+
+            public class ComplexItem : BaseItem
+            {
+                // TODO the current serializer can't do non-flat within non-flat arrays
+                [FlatArray]
+                public Complex[]? None { get; set; }
+            }
+
+            public class Complex
+            {
+                public int? ObjectId { get; set; }
+            }
+
+            [Polymorph(typeof(ValueItem), "value/id")]
+            [Polymorph(typeof(ComplexItem), "None/ObjectId")]
+            public BaseItem[]? List { get; set; }
+        }
+
+        [TestMethod()]
+        public void DeSerializePolymorphOnPathArray()
+        {
+            static Stream stream(string x) => new MemoryStream(Encoding.Unicode.GetBytes(x));
+
+            const string testInput = "<Content><List>" +
+                "<None>" +
+                    "<value>" +
+                        "<id>03000000</id>" +
+                    "</value>" +
+                "</None>" +
+                "<None>" +
+                    "<None>" +
+                        "<ObjectId>01000000</ObjectId>" +
+                    "</None>" +
+                    "<None>" +
+                        "<ObjectId>02000000</ObjectId>" +
+                    "</None>" +
+                "</None>" +
+              "</List></Content>";
+
+            // load from XML
+            XmlDocument xmlDocument = new();
+            xmlDocument.Load(stream(testInput));
+            IFileDBDocument doc = new XmlFileDbConverter<FileDBDocument_V1>().ToFileDb(xmlDocument);
+
+            // serialize & deserialize
+            FileDBDocumentDeserializer<PolymorphOnPathContainer> deserializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            var obj = deserializer.GetObjectStructureFromFileDBDocument(doc);
+
+            Assert.IsNotNull(obj);
+            var first = obj.List?[0] as PolymorphOnPathContainer.ValueItem;
+            Assert.AreEqual(3, first?.value?.id);
+            var second = obj.List?[1] as PolymorphOnPathContainer.ComplexItem;
+            Assert.AreEqual(1, second?.None?[0]?.ObjectId);
+            var third = obj.List?[1] as PolymorphOnPathContainer.ComplexItem;
+            Assert.AreEqual(2, third?.None?[1]?.ObjectId);
+
+            FileDBDocumentSerializer serializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            doc = serializer.WriteObjectStructureToFileDBDocument(obj);
+
+            // convert back to xml
+            xmlDocument = new FileDbXmlConverter().ToXml(doc);
+            Assert.AreEqual(testInput, xmlDocument.InnerXml);
+        }
+
+        private class PolymorphOnValueContainer
+        {
+            public class PolymorphTemplateElement
+            {
+                public int? ElementType { get; set; }
+
+                [Polymorph(typeof(ElementType0), "ElementType", HexValue = "00000000", Node = PolymorphRootNode.Parent)]
+                [Polymorph(typeof(ElementType1), "ElementType", HexValue = "00000001", Node = PolymorphRootNode.Parent)]
+                public Element? Element { get; set; }
+            }
+
+            public class Element
+            {
+                public int[]? Position { get; set; }
+            }
+
+            public class ElementType0 : Element
+            {
+                public byte? Rotation90 { get; set; }
+            }
+
+            public class ElementType1 : Element
+            {
+                public short? Size { get; set; }
+            }
+
+            [FlatArray]
+            public PolymorphTemplateElement[]? TemplateElement { get; set; }
+        }
+
+        [TestMethod()]
+        public void DeSerializePolymorphOnValueArray()
+        {
+            static Stream stream(string x) => new MemoryStream(Encoding.Unicode.GetBytes(x));
+
+            const string testInput = "<Content>" +
+                "<TemplateElement>" +
+                    "<ElementType>00000000</ElementType>" +
+                    "<Element>" +
+                        "<Position>0100000002000000</Position>" +
+                        "<Rotation90>01</Rotation90>" +
+                    "</Element>" +
+                "</TemplateElement>" +
+                "<TemplateElement>" +
+                    "<ElementType>00000001</ElementType>" +
+                    "<Element>" +
+                        "<Position>0200000003000000</Position>" +
+                        "<Size>0500</Size>" +
+                    "</Element>" +
+                "</TemplateElement>" +
+                "<TemplateElement>" +
+                    "<ElementType>00000002</ElementType>" +
+                    "<Element>" +
+                        "<Position>0300000004000000</Position>" +
+                    "</Element>" +
+                "</TemplateElement>" +
+              "</Content>";
+
+            // load from XML
+            XmlDocument xmlDocument = new();
+            xmlDocument.Load(stream(testInput));
+            IFileDBDocument doc = new XmlFileDbConverter<FileDBDocument_V1>().ToFileDb(xmlDocument);
+
+            // serialize & deserialize
+            FileDBDocumentDeserializer<PolymorphOnValueContainer> deserializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            var obj = deserializer.GetObjectStructureFromFileDBDocument(doc);
+
+            Assert.IsNotNull(obj);
+            Assert.AreEqual(3, obj.TemplateElement?.Length);
+            var first = obj.TemplateElement?[0].Element as PolymorphOnValueContainer.ElementType0;
+            Assert.AreEqual(1, first?.Position?[0]);
+            Assert.AreEqual((byte)1, first?.Rotation90);
+            var second = obj.TemplateElement?[1].Element as PolymorphOnValueContainer.ElementType1;
+            Assert.AreEqual(2, second?.Position?[0]);
+            Assert.AreEqual((short)5, second?.Size);
+            var third = obj.TemplateElement?[2].Element;
+            Assert.AreEqual(3, third?.Position?[0]);
+
+            FileDBDocumentSerializer serializer = new(new() { Version = FileDBDocumentVersion.Version1 });
+            doc = serializer.WriteObjectStructureToFileDBDocument(obj);
+
+            // convert back to xml
+            xmlDocument = new FileDbXmlConverter().ToXml(doc);
+            Assert.AreEqual(testInput, xmlDocument.InnerXml);
+        }
+    }
+}


### PR DESCRIPTION
There are two examples in the test cases:

```c#
[Polymorph(typeof(ValueItem), "value/id")]
[Polymorph(typeof(ComplexItem), "None/ObjectId")]
public BaseItem[]? List { get; set; }
```

```c#
[Polymorph(typeof(ElementType0), "ElementType", HexValue = "00000000", Node = PolymorphRootNode.Parent)]
[Polymorph(typeof(ElementType1), "ElementType", HexValue = "00000001", Node = PolymorphRootNode.Parent)]
public Element? Element { get; set; }
```