### PR TITLE
Feature: Rename Property Attribute

### DIFF
--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer.cs
@@ -48,7 +48,7 @@ namespace FileDBSerializing.ObjectSerializer
 
             //try to find the property this needs to go for
             Type parentType = parentObject!.GetType();
-            PropertyInfo? propertyInfo = parentType.GetProperty(PropertyName);
+            PropertyInfo? propertyInfo = GetPropertyForName(PropertyName, parentType);
 
             if (propertyInfo is null)
             {
@@ -62,6 +62,26 @@ namespace FileDBSerializing.ObjectSerializer
                 BuildArrayProperty(node, propertyInfo as PropertyInfo, parentObject);
             else
                 BuildSingleValue(node, propertyInfo as PropertyInfo, parentObject);
+        }
+
+        private PropertyInfo? GetPropertyForName(string name, Type inType)
+        {
+            PropertyInfo? result = null;
+
+            foreach(PropertyInfo propertyInfo in inType.GetProperties()){
+                RenamePropertyAttribute? piRenameAttr = propertyInfo.GetCustomAttribute<RenamePropertyAttribute>();  
+                if (piRenameAttr is not null && piRenameAttr.RenameTo == name)
+                {
+                    return propertyInfo;
+                }
+
+                if(propertyInfo.Name == name)
+                {
+                    result = propertyInfo;
+                }
+            }
+
+            return result;
         }
 
         #region SingleValue_Parent

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
@@ -52,6 +52,11 @@ namespace FileDBSerializing.ObjectSerializer
             }
         }
 
+        private string GetFileDBItemName(PropertyInfo propertyInfo)
+        {
+            return propertyInfo.GetCustomAttribute<RenamePropertyAttribute>()?.RenameTo ?? propertyInfo.Name;
+        }
+
         #region SINGLE NODES
         //parent switch for node types
         private IEnumerable<FileDBNode> BuildNode(PropertyInfo property, object parentObject)
@@ -155,7 +160,7 @@ namespace FileDBSerializing.ObjectSerializer
         private Attrib BuildSingleValueAttrib(object graph, PropertyInfo ObjectProperty)
         {
             var PrimitiveObjectInstance = ObjectProperty.GetValue(graph);
-            Attrib attr = TargetDocument.AddAttrib(ObjectProperty.Name);
+            Attrib attr = TargetDocument.AddAttrib(GetFileDBItemName(ObjectProperty));
 
             if (PrimitiveObjectInstance is null)
             {
@@ -196,7 +201,7 @@ namespace FileDBSerializing.ObjectSerializer
         {
             //Get the instance of the property for our specific object as well as the properties of its type.
             var ValueObjectInstance = ObjectProperty.GetValue(graph);
-            Tag t = TargetDocument.AddTag(ObjectProperty.Name);
+            Tag t = TargetDocument.AddTag(GetFileDBItemName(ObjectProperty));
 
             if (ValueObjectInstance is null) return t;
 
@@ -233,7 +238,7 @@ namespace FileDBSerializing.ObjectSerializer
         //Array of primitive Types
         private Attrib BuildPrimitiveArrayAttrib(object ArrayObjectInstance, PropertyInfo ObjectProperty)
         {
-            Attrib attr = TargetDocument.AddAttrib(ObjectProperty.Name);
+            Attrib attr = TargetDocument.AddAttrib(GetFileDBItemName(ObjectProperty));
             Array? arrayObject = ObjectProperty.GetValue(ArrayObjectInstance) as Array;
 
             attr.Content = arrayObject is not null ? BuildPrimitiveArrayContent(arrayObject) : new byte[0];
@@ -264,12 +269,12 @@ namespace FileDBSerializing.ObjectSerializer
         private IEnumerable<Attrib> BuildStringArray(object arrayObject, PropertyInfo objectProperty)
         {
             return BuildArrayElements(arrayObject, objectProperty, 
-                (x) => ConstructAttrib(x, TargetDocument.AddAttrib(objectProperty.Name)));
+                (x) => ConstructAttrib(x, TargetDocument.AddAttrib(GetFileDBItemName(objectProperty))));
         }
 
         private Tag BuildStringArrayTag(object arrayObject, PropertyInfo objectProperty)
         {
-            Tag tag = TargetDocument.AddTag(objectProperty.Name);
+            Tag tag = TargetDocument.AddTag(GetFileDBItemName(objectProperty));
             tag.AddChildren(BuildArrayElements(arrayObject, objectProperty,
                 (x) => ConstructAttrib(x, TargetDocument.AddAttrib(Options.NoneTag))));
             return tag;
@@ -277,7 +282,7 @@ namespace FileDBSerializing.ObjectSerializer
 
         private Tag BuildMultiNodeArray(object arrayObject, PropertyInfo objectProperty, Func<object, FileDBNode> elementConstructor)
         {
-            Tag tag = TargetDocument.AddTag(objectProperty.Name);
+            Tag tag = TargetDocument.AddTag(GetFileDBItemName(objectProperty));
             tag.AddChildren(BuildArrayElements(arrayObject, objectProperty, elementConstructor));
             return tag;
         }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/RenamePropertyAttribute.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/RenamePropertyAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileDBSerializing.ObjectSerializer
+{
+    /// <summary>
+    /// Set this attribute to rename the property in serialized FileDB.
+    /// Useful for items named eg. "default", which is a C# keyword and can't be used as Property name.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class RenamePropertyAttribute : Attribute
+    {
+        public RenamePropertyAttribute(string renameTo)
+        {
+            RenameTo = renameTo;
+        }
+
+        public string RenameTo { get; }
+    }
+}

--- a/unittests/FileDBReader-Tests/FileDBSerializer/ObjectSerializerTest.cs
+++ b/unittests/FileDBReader-Tests/FileDBSerializer/ObjectSerializerTest.cs
@@ -17,6 +17,9 @@ namespace FileDBSerializing.Tests
     [TestClass]
     public class ObjectSerializerTest
     {
+
+        #region RootObject De-/Serialization Tests
+
         [TestMethod]
         public void SerializeTest_V1() 
         {
@@ -52,7 +55,7 @@ namespace FileDBSerializing.Tests
             DocumentParser parser = new DocumentParser(FileDBDocumentVersion.Version1);
             IFileDBDocument doc = parser.LoadFileDBDocument(x);
 
-            FileDBDocumentDeserializer<RootObject> objectdeserializer = new FileDBDocumentDeserializer<RootObject>(new() { Version = FileDBDocumentVersion.Version1});
+            FileDBDocumentDeserializer<RootObject> objectdeserializer = new FileDBDocumentDeserializer<RootObject>(new() { Version = FileDBDocumentVersion.Version1 });
 
             var DeserializedDocument = objectdeserializer.GetObjectStructureFromFileDBDocument(doc);
 
@@ -94,6 +97,95 @@ namespace FileDBSerializing.Tests
 
             result.Should().BeEquivalentTo(TestDataSources.GetTestAsset());
         }
+
+        #endregion
+
+        #region RenamedRootObject De-/Serialization Tests
+
+
+        [TestMethod]
+        public void SerializeTestRenamed_V1()
+        {
+            var expected = File.OpenRead("FileDBSerializer/Testfiles/objectserializing/version1.filedb");
+
+            var obj = TestDataSources.GetTestAssetRenamed();
+            FileDBSerializer<RenamedRootObject> objectserializer = new FileDBSerializer<RenamedRootObject>(FileDBDocumentVersion.Version1);
+
+            Stream result = new MemoryStream();
+            objectserializer.Serialize(result, obj);
+
+            Assert.IsTrue(FileConversionTests.StreamsAreEqual(expected, result));
+        }
+
+        [TestMethod]
+        public void SerializeTestRenamed_V2()
+        {
+            var expected = File.OpenRead("FileDBSerializer/Testfiles/objectserializing/version2.filedb");
+
+            var obj = TestDataSources.GetTestAssetRenamed();
+            FileDBSerializer<RenamedRootObject> objectserializer = new FileDBSerializer<RenamedRootObject>(FileDBDocumentVersion.Version2);
+            MemoryStream result = new MemoryStream();
+            objectserializer.Serialize(result, obj);
+
+            Assert.IsTrue(FileConversionTests.StreamsAreEqual(expected, result));
+        }
+
+
+
+        [TestMethod]
+        public void DeserializeTestRenamed_V1()
+        {
+            var x = File.OpenRead("FileDBSerializer/Testfiles/objectserializing/version1.filedb");
+
+            DocumentParser parser = new DocumentParser(FileDBDocumentVersion.Version1);
+            IFileDBDocument doc = parser.LoadFileDBDocument(x);
+
+            FileDBDocumentDeserializer<RenamedRootObject> objectdeserializer = new FileDBDocumentDeserializer<RenamedRootObject>(new() { Version = FileDBDocumentVersion.Version1 });
+
+            var DeserializedDocument = objectdeserializer.GetObjectStructureFromFileDBDocument(doc);
+
+            DeserializedDocument.Should().BeEquivalentTo(TestDataSources.GetTestAssetRenamed());
+        }
+
+        [TestMethod]
+        public void DeserializeTestRenamed_V2()
+        {
+            var x = File.OpenRead("FileDBSerializer/Testfiles/objectserializing/version2.filedb");
+
+            DocumentParser parser = new DocumentParser(FileDBDocumentVersion.Version2);
+            IFileDBDocument doc = parser.LoadFileDBDocument(x);
+
+            FileDBDocumentDeserializer<RenamedRootObject> objectdeserializer = new FileDBDocumentDeserializer<RenamedRootObject>(new() { Version = FileDBDocumentVersion.Version1 });
+
+            var DeserializedDocument = objectdeserializer.GetObjectStructureFromFileDBDocument(doc);
+
+            DeserializedDocument.Should().BeEquivalentTo(TestDataSources.GetTestAssetRenamed());
+        }
+
+
+
+        [TestMethod]
+        public void StaticConvertTestRenamed_Serialize()
+        {
+            var expected = File.OpenRead("FileDBSerializer/Testfiles/objectserializing/version2.filedb");
+
+            var obj = TestDataSources.GetTestAssetRenamed();
+
+            Stream Result = FileDBConvert.SerializeObject(obj, new() { Version = FileDBDocumentVersion.Version2 });
+
+            Assert.IsTrue(FileConversionTests.StreamsAreEqual(expected, Result));
+        }
+
+        [TestMethod]
+        public void StaticConvertTestRenamed_Deserialize()
+        {
+            var source = File.OpenRead("FileDBSerializer/Testfiles/objectserializing/version2.filedb");
+            RenamedRootObject? result = FileDBConvert.DeserializeObject<RenamedRootObject>(source, new() { Version = FileDBDocumentVersion.Version2 });
+
+            result.Should().BeEquivalentTo(TestDataSources.GetTestAssetRenamed());
+        }
+
+        #endregion
 
 
         [TestMethod()]

--- a/unittests/FileDBReader-Tests/TestDataSources.cs
+++ b/unittests/FileDBReader-Tests/TestDataSources.cs
@@ -24,6 +24,20 @@ namespace FileDBReader_Tests
             return root;
         }
 
+        internal static RenamedRootObject GetTestAssetRenamed()
+        {
+            RenamedRootObject root = new RenamedRootObject();
+            root.UnknownCount = 5;
+            ChildElement Child = new ChildElement() { ID = 1337 };
+            root.DumbChild = Child;
+            root.IntelligentManager = new SomethingManager() { Child = Child, SomethingCount = 69420, SomethingValue = 3.1415f };
+            root.IntArray = new int[5] { 1337, 42, 69, 420, 31 };
+            root.ChildArray = new ChildElement[2] { new ChildElement() { ID = 69420 }, new ChildElement() { ID = 1234 } };
+            root.SimpleString = "Modders gonna take over the world!";
+            root.strArray = new string[] { "There are no plans for a console version of Anno 1800, or to support controllers in the PC version of the game", "We only made this complete Console UI for fun" };
+            return root;
+        }
+
         internal static IFileDBDocument BuildDocument<T>() where T : IFileDBDocument, new()
         {
             var filedb = new T();

--- a/unittests/FileDBReader-Tests/TestSerializationData/RootObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/RootObject.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using System.Runtime.Serialization;
 using FileDBSerializing.EncodingAwareStrings;
+using FileDBSerializing.ObjectSerializer;
 
 namespace FileDBSerializing.Tests.TestData
 {
@@ -18,6 +19,26 @@ namespace FileDBSerializing.Tests.TestData
         public ChildElement[]? RefArray { get; set; }
         public UnicodeString? SimpleString { get; set; }
         public string[]? StringArray { get; set; }
+    }
+
+    public record RenamedRootObject
+    {
+        [RenameProperty("RootCount")]
+        public int? UnknownCount { get; set; }
+
+        [RenameProperty("DumbManager")]
+        public SomethingManager? IntelligentManager { get; set; }
+        public ChildElement? DumbChild { get; set; }
+
+        [RenameProperty("PrimitiveArray")]
+        public int[]? IntArray { get; set; }
+
+        [RenameProperty("RefArray")]
+        public ChildElement[]? ChildArray { get; set; }
+        public UnicodeString? SimpleString { get; set; }
+
+        [RenameProperty("StringArray")]
+        public string[]? strArray { get; set; }
     }
 
     public record SomethingManager


### PR DESCRIPTION
Added RenamePropertyAttribute, which is used to change the FileDB Item Name from the property's name when de-/serializing objects.

Unit testing is done by testing against the preexisting test files but with a Class that has different property names that get renamed to the original names.

Now also PR'ed against the correct branch. Ooops.