### PR TITLE
[serialization-rewrite] Rework of Handlers to not access the parent layer

### DIFF
--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
@@ -38,18 +38,16 @@ namespace FileDBSerializing.ObjectSerializer
         {
             foreach (var property in properties)
             {
-                foreach (var _ in BuildNode(property, parentObject))
+                var handler = HandlerProvider.GetHandlerFor(property);
+
+                var item = property.GetValue(parentObject);
+                string tagName = property.Name;
+
+                foreach (var _ in handler.Handle(item, tagName, TargetDocument, Options))
                 {
                     yield return _;
                 }
             }
-        }
-
-        private IEnumerable<FileDBNode> BuildNode(PropertyInfo property, object parentObject)
-        {
-            var handler = HandlerProvider.GetHandlerFor(property);
-            var node = handler.Handle(parentObject, property, TargetDocument, Options);
-            return node;
         }
     }
 }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/ArrayHandlerSelector.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/ArrayHandlerSelector.cs
@@ -1,27 +1,30 @@
 ﻿using FileDBSerializer.ObjectSerializer.SerializationHandlers;
 using FileDBSerializing.ObjectSerializer;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace FileDBSerializer.ObjectSerializer.HandlerSelector
 {
     public class ArrayHandlerSelector : IHandlerSelector
     {
-        public HandlerType GetHandlerFor(PropertyInfo propertyInfo)
+        public HandlerType GetHandlerFor(Type itemType, IEnumerable<Attribute> customAttributes)
         {            
-            Type arrayContentType = propertyInfo.GetNullablePropertyType().GetElementType()!;
+            Type arrayContentType = itemType.GetNullableType().GetElementType()!;
 
-            if (arrayContentType.IsPrimitiveType())
+
+            if (customAttributes.Any((attr) => attr.GetType() == typeof(FlatArrayAttribute)))
+            {
+                return HandlerType.FlatArray;
+            }
+            else if (arrayContentType.IsPrimitiveType())
             {
                 return HandlerType.PrimitiveArray;
             }
             else if (arrayContentType.IsStringType())
             {
                 return HandlerType.StringArray;
-            }
-            else if (propertyInfo.HasAttribute<FlatArrayAttribute>())
-            {
-                return HandlerType.FlatArray;
             }
             else if (arrayContentType.IsReference())
             {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/IHandlerSelector.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/IHandlerSelector.cs
@@ -1,11 +1,12 @@
 ﻿using FileDBSerializer.ObjectSerializer.SerializationHandlers;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace FileDBSerializer.ObjectSerializer.HandlerSelector
 {
     public interface IHandlerSelector
     {
-        public HandlerType GetHandlerFor(PropertyInfo propertyInfo);
+        public HandlerType GetHandlerFor(Type itemType, IEnumerable<Attribute> customAttributes);
     }
 }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/ReferenceTypeHandlerSelector.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/ReferenceTypeHandlerSelector.cs
@@ -1,14 +1,15 @@
 ﻿using FileDBSerializer.ObjectSerializer.SerializationHandlers;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace FileDBSerializer.ObjectSerializer.HandlerSelector
 {
     public class ReferenceTypeHandlerSelector : IHandlerSelector
     {
-        public HandlerType GetHandlerFor(PropertyInfo propertyInfo)
+        public HandlerType GetHandlerFor(Type itemType, IEnumerable<Attribute> customAttributes)
         {
-            //make check for IValue here laterz(tm)
+            //make check for ITuple here laterz(tm)
             return HandlerType.Reference;
         }
     }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/TopLevelHandlerSelector.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/HandlerSelector/TopLevelHandlerSelector.cs
@@ -1,15 +1,16 @@
 ﻿using FileDBSerializer.ObjectSerializer.SerializationHandlers;
 using FileDBSerializing.ObjectSerializer;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace FileDBSerializer.ObjectSerializer.HandlerSelector
 {
-    public class TopLevelHandlerSelector
+    public class TopLevelHandlerSelector : IHandlerSelector
     {
-        public HandlerType GetHandlerFor(PropertyInfo propertyInfo)
+        public HandlerType GetHandlerFor(Type itemType, IEnumerable<Attribute> customAttributes)
         {
-            var propertyType = propertyInfo.GetNullablePropertyType();
+            var propertyType = itemType.GetNullableType();
             if (propertyType.IsStringType())
                 return HandlerType.String;
 
@@ -17,11 +18,11 @@ namespace FileDBSerializer.ObjectSerializer.HandlerSelector
                 return HandlerType.Primitive;
 
             if (propertyType.IsArray())
-                return Selectors.ArrayHandlerService.GetHandlerFor(propertyInfo);
+                return Selectors.ArrayHandlerService.GetHandlerFor(itemType, customAttributes);
 
             //this needs to be after array
             if (propertyType.IsReference())
-                return Selectors.ReferenceTypeHandlerService.GetHandlerFor(propertyInfo);
+                return Selectors.ReferenceTypeHandlerService.GetHandlerFor(itemType, customAttributes);
 
             throw new InvalidOperationException($"PropertyType {propertyType.Name} could not be resolved to a FileDB document element.");
 

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/HandlerProvider.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/HandlerProvider.cs
@@ -31,7 +31,12 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 
         public static ISerializationHandler GetHandlerFor(PropertyInfo property)
         {
-            var type = Selectors.TopLevelHandlerService.GetHandlerFor(property);
+            return GetHandlerFor(property.PropertyType, property.GetCustomAttributes());
+        }
+
+        public static ISerializationHandler GetHandlerFor(Type itemType, IEnumerable<Attribute> customAttributes)
+        {
+            var type = Selectors.TopLevelHandlerService.GetHandlerFor(itemType, customAttributes);
             return GetFromType(type);
         }
     }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ISerializationHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ISerializationHandler.cs
@@ -7,6 +7,6 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 {
     public interface ISerializationHandler
     {
-        public IEnumerable<FileDBNode> Handle(object graph, PropertyInfo property, IFileDBDocument workingDocument, FileDBSerializerOptions options);
+        public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options);
     }
 }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveArrayHandler.cs
@@ -3,6 +3,7 @@ using FileDBSerializing.ObjectSerializer;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 
@@ -17,10 +18,13 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
             PrimitiveConverter ??= new PrimitiveTypeConverter();
         }
 
-        public IEnumerable<FileDBNode> Handle(object graph, PropertyInfo property, IFileDBDocument workingDocument, FileDBSerializerOptions options)
+        public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options)
         {
-            var arrayInstance = property.GetValue(graph) as Array;
-            Attrib attr = workingDocument.AddAttrib(property.Name);
+            var arrayInstance = item as Array;
+            if (arrayInstance is null && options.SkipSimpleNullValues)
+                return Enumerable.Empty<FileDBNode>();
+
+            Attrib attr = workingDocument.AddAttrib(tagName);
 
             if (arrayInstance is null)
             {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveHandler.cs
@@ -2,6 +2,7 @@
 using FileDBSerializing.EncodingAwareStrings;
 using FileDBSerializing.ObjectSerializer;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
@@ -26,14 +27,17 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
         /// <param name="workingDocument"></param>
         /// <param name="options"></param>
         /// <returns>An attrib containing a byte representation of the value</returns>
-        public IEnumerable<FileDBNode> Handle(object graph, PropertyInfo property, IFileDBDocument workingDocument, FileDBSerializerOptions options)
+        public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options)
         {
-            var PrimitiveObjectInstance = property.GetValue(graph);
-            Attrib attr = workingDocument.AddAttrib(property.Name);
+            if(item is null && options.SkipSimpleNullValues)
+                return Enumerable.Empty<FileDBNode>();
 
-            attr.Content = PrimitiveObjectInstance is null ?
+
+            Attrib attr = workingDocument.AddAttrib(tagName);
+
+            attr.Content = item is null ?
                     new byte[0]
-                    : PrimitiveConverter!.GetBytes(PrimitiveObjectInstance);
+                    : PrimitiveConverter!.GetBytes(item);
             return attr.AsEnumerable();
         }
     }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceTypeHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceTypeHandler.cs
@@ -7,20 +7,20 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 {
     public class ReferenceTypeHandler : ISerializationHandler
     {
-        public IEnumerable<FileDBNode> Handle(object graph, PropertyInfo property, IFileDBDocument workingDocument, FileDBSerializerOptions options)
+        public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options)
         {
             //Get the instance of the property for our specific object as well as the properties of its type.
-            var propertyInstance = property.GetValue(graph);
-            Tag t = workingDocument.AddTag(property.Name);
-            if (propertyInstance is null) return t.AsEnumerable();
+            Tag t = workingDocument.AddTag(tagName);
+            if (item is null) return t.AsEnumerable();
 
-            PropertyInfo[] properties = propertyInstance.GetType().GetProperties();
+            PropertyInfo[] properties = item.GetType().GetProperties();
 
             foreach (var _prop in properties)
             {
                 //use a handler for the children properties
                 var handler = HandlerProvider.GetHandlerFor(_prop);
-                t.AddChildren(handler.Handle(propertyInstance, _prop, workingDocument, options));
+                var childItem = _prop.GetValue(item);
+                t.AddChildren(handler.Handle(childItem, _prop.Name, workingDocument, options));
             }
             return t.AsEnumerable();
         }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/StringArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/StringArrayHandler.cs
@@ -12,12 +12,13 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 {
     public class StringArrayHandler : ISerializationHandler
     {
-        public IEnumerable<FileDBNode> Handle(object graph, PropertyInfo property, IFileDBDocument workingDocument, FileDBSerializerOptions options)
+        public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options)
         {
-            var arrayInstance = property.GetValue(graph) as Array;
-            if (arrayInstance is null) throw new InvalidOperationException($"{property.PropertyType} cannot be casted into an Array");
+            Tag t = workingDocument.AddTag(tagName);
 
-            Tag t = workingDocument.AddTag(property.Name);
+            var arrayInstance = item as Array;
+            if (arrayInstance is null) 
+                return t.AsEnumerable();
 
             for (int i = 0; i < arrayInstance.Length; i++)
             {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/StringHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/StringHandler.cs
@@ -3,6 +3,7 @@ using FileDBSerializing.EncodingAwareStrings;
 using FileDBSerializing.ObjectSerializer;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
@@ -19,20 +20,22 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
         /// <param name="workingDocument"></param>
         /// <param name="options"></param>
         /// <returns>Attrib containing the string in the byte representation specified either by encodingawarestring or default encoding</returns>
-        public IEnumerable<FileDBNode> Handle(object graph, PropertyInfo property, IFileDBDocument workingDocument, FileDBSerializerOptions options)
+        public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options)
         {
-            var objectInstance = property.GetValue(graph);
-            Attrib attr = workingDocument.AddAttrib(property.Name);
+            if (item is null && options.SkipSimpleNullValues)
+                return Enumerable.Empty<FileDBNode>();
 
-            if (objectInstance is null)
+            Attrib attr = workingDocument.AddAttrib(tagName);
+
+            if (item is null)
             {
                 attr.Content = new byte[0];
             }
             else
             {
-                attr.Content = objectInstance is EncodingAwareString ?
-                    ((EncodingAwareString)objectInstance).GetBytes()
-                    : options.DefaultEncoding.GetBytes((String)objectInstance!);
+                attr.Content = item is EncodingAwareString ?
+                    ((EncodingAwareString)item).GetBytes()
+                    : options.DefaultEncoding.GetBytes((String)item!);
             }
 
             return attr.AsEnumerable();

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/TupleHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/TupleHandler.cs
@@ -11,7 +11,7 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 {
     internal class TupleHandler : ISerializationHandler
     {
-        public IEnumerable<FileDBNode> Handle(object graph, PropertyInfo property, IFileDBDocument workingDocument, FileDBSerializerOptions options)
+        public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options)
         {
             throw new NotImplementedException();
         }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
@@ -28,6 +28,16 @@ namespace FileDBSerializing.ObjectSerializer
             if (type.IsValueType) return Activator.CreateInstance(type);
             return null;
         }
+
+        internal static Type GetNullableType(this Type type)
+        {
+            Type? _nulltype;
+            if ((_nulltype = Nullable.GetUnderlyingType(type)) is not null)
+            {
+                return _nulltype;
+            }
+            return type;
+        }
     }
 
     internal static class IEnumerableExtensions
@@ -47,12 +57,7 @@ namespace FileDBSerializing.ObjectSerializer
 
         internal static Type GetNullablePropertyType(this PropertyInfo that)
         {
-            Type? _nulltype;
-            if ((_nulltype = Nullable.GetUnderlyingType(that.PropertyType)) is not null)
-            {
-                return _nulltype;
-            }
-            return that.PropertyType;
+            return that.PropertyType.GetNullableType(); ;
         }
     }
 


### PR DESCRIPTION
Handlers now get passed the object they handle instead of getting it from the parent object. This makes the creation of None-Tags for Reference Arrays simpler and enables Reference Arrays to simply call the Reference Handler for its items with the None-Tag Name.

This PR targets the serialization-rewrite branch!

Currently all unit tests work, but I feel like they have to be more comprehensive to cover all possible edge cases...