### PR TITLE
Added interpretation of sparse grid of AreaIDs

### DIFF
--- a/FileFormats/Island_Gamedata_V2.xml
+++ b/FileFormats/Island_Gamedata_V2.xml
@@ -14,6 +14,12 @@
     <Convert Path ="//HeightMap/HeightMap" Type="UInt16" Structure ="List" />
     <Convert Path ="//StreetID/val" Type="Byte" Structure ="List" />
     <Convert Path ="//AreaIDs/val" Type="Byte" Structure ="List" />
+    <Convert Path ="//AreaIDs/SparseEnabled" Type="Byte" />
+    <Convert Path ="//AreaIDs/block/x" Type="Int16" />
+    <Convert Path ="//AreaIDs/block/y" Type="Int16" />
+    <Convert Path ="//AreaIDs/block/mode" Type="Byte" />
+    <Convert Path ="//AreaIDs/block/default" Type="Byte" Structure="List" />
+    <Convert Path ="//AreaIDs/block/values" Type="Byte" Structure="List" />
     <Convert Path ="//EnvironmentGRid/val" Type="Byte" Structure ="List" />
     <Convert Path ="//bits" Type="Byte" Structure ="List" />
     <Convert Path ="//PlayableArea" Type="Int32" Structure ="List" />

--- a/FileFormats/Island_Gamedata_V2.xml
+++ b/FileFormats/Island_Gamedata_V2.xml
@@ -14,7 +14,7 @@
     <Convert Path ="//HeightMap/HeightMap" Type="UInt16" Structure ="List" />
     <Convert Path ="//StreetID/val" Type="Byte" Structure ="List" />
     <Convert Path ="//AreaIDs/val" Type="Byte" Structure ="List" />
-    <Convert Path ="//AreaIDs/SparseEnabled" Type="Byte" />
+    <Convert Path ="//AreaIDs/SparseEnabled" Type="Boolean" />
     <Convert Path ="//AreaIDs/block/x" Type="Int16" />
     <Convert Path ="//AreaIDs/block/y" Type="Int16" />
     <Convert Path ="//AreaIDs/block/mode" Type="Byte" />


### PR DESCRIPTION
It is used for some islands in data24.rda use sparse grid to specify their AreaIDs. For example `data/sessions/island/pool/colony01/colony01_l_05/colony01_l_05_river_01`.

By the way I summarised that when `//AreaIDs/block/mode` is:
- `1` the `./x` and `./y` area meant to specify width and height of individual sub grids
- `0` then it probably marks end of the sparse grid
- not there then `./x` and `./y` specify starting position where this specific sub grid is in overall grid and `./values` contains grid values of same format as were in `//AreaIDs/val`
- `2` then `./x` and `./y` specify starting position where this specific sub grid and it means that this entire sub grid has same value stored in `./default`