### PR TITLE
Fix and Finish new Deserializers

### DIFF
--- a/FileDBSerializer/FileDBSerializer/LookUps/FileDBDocumentLookupExtension.cs
+++ b/FileDBSerializer/FileDBSerializer/LookUps/FileDBDocumentLookupExtension.cs
@@ -21,13 +21,13 @@ namespace FileDBSerializing.LookUps
             return document.Roots.SelectNodes(Lookup, condition);
         }
 
-        public static FileDBNode SelectSingleNode(this IFileDBDocument document, String Lookup)
+        public static FileDBNode? SelectSingleNode(this IFileDBDocument document, String Lookup)
         {
             return document.Roots.SelectSingleNode(Lookup);
         }
 
         //Overload with Condition
-        public static FileDBNode SelectSingleNode(this IFileDBDocument document, String Lookup, LookupCondition condition)
+        public static FileDBNode? SelectSingleNode(this IFileDBDocument document, String Lookup, LookupCondition condition)
         {
             return document.Roots.SelectSingleNode(Lookup, condition);
         }

--- a/FileDBSerializer/FileDBSerializer/LookUps/FileDBLookupExtension.cs
+++ b/FileDBSerializer/FileDBSerializer/LookUps/FileDBLookupExtension.cs
@@ -16,19 +16,19 @@ namespace FileDBSerializing.LookUps
             return SelectNodes(Collection, Lookup, node => true);
         }
 
-        public static FileDBNode SelectSingleNode(this IEnumerable<FileDBNode> Collection, String Lookup)
+        public static FileDBNode? SelectSingleNode(this IEnumerable<FileDBNode> Collection, String Lookup)
         {
             return SelectSingleNode(Collection, Lookup, node => true);
         }
 
-        public static Tag SelectSingleTag(this IEnumerable<FileDBNode> Collection, String Lookup)
+        public static Tag? SelectSingleTag(this IEnumerable<FileDBNode> Collection, String Lookup)
         {
-            return (Tag)SelectSingleNode(Collection, Lookup, node => node is Tag);
+            return SelectSingleNode(Collection, Lookup, node => node is Tag) as Tag;
         }
 
-        public static Attrib SelectSingleAttrib(this IEnumerable<FileDBNode> Collection, String Lookup)
+        public static Attrib? SelectSingleAttrib(this IEnumerable<FileDBNode> Collection, String Lookup)
         {
-            return (Attrib)SelectSingleNode(Collection, Lookup, node => node is Attrib);
+            return SelectSingleNode(Collection, Lookup, node => node is Attrib) as Attrib;
         }
 
         #region LookupMethods
@@ -75,7 +75,7 @@ namespace FileDBSerializing.LookUps
         /// <param name="Lookup">Lookup Path of the node</param>
         /// <param name="condition">Condition matching the delegate type LookupConditon. This condition is matched only for the resulting nodes (last element of the lookup path)!.</param>
         /// <returns>The first FileDBNode matching the given condition and Lookup, or null, if no such node is found.</returns>
-        public static FileDBNode SelectSingleNode(this IEnumerable<FileDBNode> Collection, String Lookup, LookupCondition condition)
+        public static FileDBNode? SelectSingleNode(this IEnumerable<FileDBNode> Collection, String Lookup, LookupCondition condition)
         {
             try
             {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/FlatArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/FlatArrayHandler.cs
@@ -1,0 +1,57 @@
+﻿using FileDBSerializing;
+using FileDBSerializing.ObjectSerializer;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
+{
+    public class FlatArrayHandler : IDeserializationHandler
+    {
+        public object? Handle(IEnumerable<FileDBNode> nodes, Type targetType, FileDBSerializerOptions options)
+        {
+            var actualTargetType = targetType.GetNullableType();
+            var listContentType = actualTargetType.GetGenericArguments().Single()!;
+
+            var elemCount = nodes.Count();
+            var itemHandler = HandlerProvider.GetHandlerFor(listContentType);
+
+            var listConstructor = actualTargetType.GetConstructor(new Type[] { });
+            var listInstance = (IList)listConstructor!.Invoke(new object[] { });
+
+            if (itemHandler is not TupleHandler)
+            {
+                for (int i = 0; i < elemCount; i++)
+                {
+                    var none = nodes.ElementAt(i);
+                    object? listEntry = itemHandler.Handle(none.AsEnumerable(), listContentType, options);
+                    listInstance.Add(listEntry);
+                }
+            }
+            else
+            {
+                int stride = listContentType.GetNullableType().GetGenericArguments().Length;
+                if (elemCount % stride != 0)
+                    throw new InvalidOperationException("The amount of items in this List of Tuples cannot properly fill Tuples without remainder.\r\n" +
+                        $"There are {elemCount % stride} items too many.");
+
+                for (int i = 0; i < elemCount; i += stride)
+                {
+                    FileDBNode[] tupleItems = new FileDBNode[stride];
+                    for (int j = 0; j < tupleItems.Length; j++)
+                    {
+                        tupleItems[j] = nodes.ElementAt(i + j);
+                    }
+
+                    object? listEntry = itemHandler.Handle(tupleItems, listContentType, options);
+                    listInstance.Add(listEntry);
+                }
+
+            }
+            return listInstance;
+        }
+    }
+}

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/HandlerProvider.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/HandlerProvider.cs
@@ -15,6 +15,7 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
             { HandlerType.PrimitiveArray, new PrimitiveArrayHandler() },
             { HandlerType.ReferenceArray, new ReferenceArrayHandler() },
             { HandlerType.String, new StringHandler()},
+            { HandlerType.ITuple, new TupleHandler() },
             { HandlerType.List, new ListHandler() }
         };
 

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/HandlerProvider.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/HandlerProvider.cs
@@ -14,7 +14,8 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
             { HandlerType.Reference, new ReferenceTypeHandler() },
             { HandlerType.PrimitiveArray, new PrimitiveArrayHandler() },
             { HandlerType.ReferenceArray, new ReferenceArrayHandler() },
-            { HandlerType.String, new StringHandler()}
+            { HandlerType.String, new StringHandler()},
+            { HandlerType.List, new ListHandler() }
         };
 
         public static IDeserializationHandler GetFromType(HandlerType handlerType)

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/HandlerProvider.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/HandlerProvider.cs
@@ -16,6 +16,7 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
             { HandlerType.ReferenceArray, new ReferenceArrayHandler() },
             { HandlerType.String, new StringHandler()},
             { HandlerType.ITuple, new TupleHandler() },
+            { HandlerType.FlatArray, new FlatArrayHandler() },
             { HandlerType.List, new ListHandler() }
         };
 

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ListHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ListHandler.cs
@@ -1,0 +1,41 @@
+﻿using FileDBSerializing;
+using FileDBSerializing.ObjectSerializer;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
+{
+    public class ListHandler : IDeserializationHandler
+    {
+        public object? Handle(IEnumerable<FileDBNode> nodes, Type targetType, FileDBSerializerOptions options)
+        {
+            if (nodes.Count() != 1)
+                throw new InvalidOperationException("ListHandler can handle exactly one node");
+            var node = nodes.First();
+            if (node is not Tag tag)
+                throw new InvalidOperationException("Only Tags can be handled by ListHandler");
+
+            //Add array entries to the mix
+            var actualTargetType = targetType.GetNullableType();
+            var listContentType = actualTargetType.GetGenericArguments().Single()!;
+
+            var elemCount = tag.Children.Count();
+            var itemHandler = HandlerProvider.GetHandlerFor(listContentType);
+
+            var listConstructor = actualTargetType.GetConstructor(new Type[] { });
+            var listInstance = (IList)listConstructor!.Invoke(new object[] { });
+
+            for (int i = 0; i < elemCount; i++)
+            {
+                var none = tag.Children.ElementAt(i);
+                object? listEntry = itemHandler.Handle(none.AsEnumerable(), listContentType, options);
+                listInstance.Add(listEntry);
+            }
+            return listInstance;
+        }
+    }
+}

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/PrimitiveArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/PrimitiveArrayHandler.cs
@@ -9,10 +9,8 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
 {
     public class PrimitiveArrayHandler : IDeserializationHandler
     {
-        private static PrimitiveTypeConverter? PrimitiveConverter;
         public PrimitiveArrayHandler()
         {
-            PrimitiveConverter ??= new PrimitiveTypeConverter();
         }
 
         public object? Handle(IEnumerable<FileDBNode> nodes, Type targetType, FileDBSerializerOptions options)
@@ -37,7 +35,7 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
             {
                 //todo maybe make this nicer and faster with memory<T>
                 var slice = attrib.Content.Skip(i * arrayval_size).Take(arrayval_size);
-                var entry = PrimitiveConverter!.GetObject(elem_type, slice.ToArray());
+                var entry = PrimitiveTypeConverter.GetObject(elem_type, slice.ToArray());
                 arrayInstance.SetValue(entry, i);
             }
 

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/PrimitiveHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/PrimitiveHandler.cs
@@ -8,11 +8,9 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
 {
     public class PrimitiveHandler : IDeserializationHandler
     {
-        private static PrimitiveTypeConverter? PrimitiveConverter;
 
         public PrimitiveHandler()
         {
-            PrimitiveConverter ??= new PrimitiveTypeConverter();
         }
 
         public object? Handle(IEnumerable<FileDBNode> nodes, Type targetType, FileDBSerializerOptions options)
@@ -24,7 +22,7 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
             if (node is not Attrib attrib)
                 throw new InvalidOperationException("Only attribs can be handled by PrimitiveHandler");
 
-            return PrimitiveConverter!.GetObject(actualTargetType, attrib.Content);
+            return PrimitiveTypeConverter.GetObject(actualTargetType, attrib.Content);
         }
     }
 }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ReferenceArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ReferenceArrayHandler.cs
@@ -37,11 +37,33 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
             var itemHandler = HandlerProvider.GetHandlerFor(arrayContentType);
 
             var arrayInstance = Array.CreateInstance(arrayContentType, elemCount);
-            for (int i = 0; i < elemCount; i++)
+
+            if(itemHandler is not TupleHandler)
             {
-                var none = tag.Children.ElementAt(i+1); //Offset by one due to size element
-                object? arrayEntry = itemHandler.Handle(none.AsEnumerable(), arrayContentType, options);
-                arrayInstance.SetValue(arrayEntry, i);
+                for (int i = 0; i < elemCount; i++)
+                {
+                    var none = tag.Children.ElementAt(i + 1); //Offset by one due to size element
+                    object? arrayEntry = itemHandler.Handle(none.AsEnumerable(), arrayContentType, options);
+                    arrayInstance.SetValue(arrayEntry, i);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < elemCount; i++)
+                {
+                    var nestedWrapper = tag.Children.ElementAt(i + 1);
+
+                    if (nestedWrapper is not Tag nestedTag)
+                        throw new InvalidOperationException("A Tuple in a reference array must be a Tag.");
+
+                    int nestedTupleSize = arrayContentType.GetNullableType().GetGenericArguments().Length;
+
+                    if (nestedTag.Children.Count != nestedTupleSize)
+                        throw new InvalidOperationException("The nested Tuple Wrapper does not have the correct number of items for the nested Tuple.");
+
+                    object? arrayEntry = itemHandler.Handle(nestedTag.Children, arrayContentType, options);
+                    arrayInstance.SetValue(arrayEntry, i);
+                }
             }
             return arrayInstance;
         }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/TupleHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/TupleHandler.cs
@@ -1,0 +1,57 @@
+﻿using FileDBSerializing;
+using FileDBSerializing.ObjectSerializer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
+{
+    public class TupleHandler : IDeserializationHandler
+    {
+        public object? Handle(IEnumerable<FileDBNode> nodes, Type targetType, FileDBSerializerOptions options)
+        {
+            var actualTargetType = targetType.GetNullableType();
+            var tupleContentTypes = actualTargetType.GetGenericArguments();
+            int tupleSize = tupleContentTypes.Length;
+
+            if (nodes.Count() != tupleSize)
+                throw new InvalidOperationException("TupleHandler must receive the exact amount of nodes that the tuple type has as generic arguments.\r\n" +
+                    $"Expected {tupleSize} but got {nodes.Count()}.");
+
+            object?[] items = new object[tupleSize];
+
+            for (int i = 0;i < tupleSize; i++)
+            {
+                var itemHandler = HandlerProvider.GetHandlerFor(tupleContentTypes[i]);
+                if(itemHandler is not TupleHandler)
+                {
+                    var none = nodes.ElementAt(i);
+                    object? tupleItem = itemHandler.Handle(none.AsEnumerable(), tupleContentTypes[i], options);
+                    items[i] = tupleItem;
+                }
+                else
+                {
+                    var nestedWrapper = nodes.ElementAt(i);
+
+                    if(nestedWrapper is not Tag nestedTag)
+                        throw new InvalidOperationException("A nested Tuple Wrapper must be a Tag.");
+
+                    int nestedTupleSize = tupleContentTypes[i].GetNullableType().GetGenericArguments().Length;
+
+                    if(nestedTag.Children.Count != nestedTupleSize)
+                        throw new InvalidOperationException("The nested Tuple Wrapper does not have the correct number of items for the nested Tuple.");
+
+                    object? tupleItem = itemHandler.Handle(nestedTag.Children, tupleContentTypes[i], options);
+                    items[i] = tupleItem;
+                }
+            }
+
+            var tupleConstructor = actualTargetType.GetConstructor(tupleContentTypes);
+            var tupleInstance = tupleConstructor!.Invoke(items);
+
+            return tupleInstance;
+        }
+    }
+}

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer.cs
@@ -12,7 +12,6 @@ namespace FileDBSerializing.ObjectSerializer
     public class FileDBDocumentDeserializer<T> where T : class, new()
     {
         private FileDBSerializerOptions Options;
-        private PrimitiveTypeConverter PrimitiveConverter = new PrimitiveTypeConverter();
         private T TargetObject;
         private Type TargetType;
 

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer_OLD.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentDeserializer_OLD.cs
@@ -10,7 +10,6 @@ namespace FileDBSerializing.ObjectSerializer
     public class FileDBDocumentDeserializer_OLD<T> where T : class, new()
     {
         private FileDBSerializerOptions Options;
-        private PrimitiveTypeConverter PrimitiveConverter = new PrimitiveTypeConverter();
         private T TargetObject;
         private Type TargetType;
 
@@ -151,7 +150,7 @@ namespace FileDBSerializing.ObjectSerializer
             for (int i = 0; i < ArrayLength; i++)
             {
                 byte[] SpanSlice = ContentSpan.Slice(i * contentSize, contentSize).ToArray();
-                var ArrayEntry = PrimitiveConverter.GetObject(ContentType, SpanSlice);
+                var ArrayEntry = PrimitiveTypeConverter.GetObject(ContentType, SpanSlice);
                 ArrayInstance.SetValue(ArrayEntry, i);
             }
 
@@ -256,7 +255,7 @@ namespace FileDBSerializing.ObjectSerializer
             object? PropertyInstance = null;
 
             if (PropertyType.IsPrimitiveType())
-                PropertyInstance = PrimitiveConverter.GetObject(PropertyType, attrib.Content);
+                PropertyInstance = PrimitiveTypeConverter.GetObject(PropertyType, attrib.Content);
             else if (PropertyType.IsStringType())
                 PropertyInstance = InstanceString(PropertyType, attrib.Content);
 

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer_OLD.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer_OLD.cs
@@ -14,7 +14,6 @@ namespace FileDBSerializing.ObjectSerializer
     {
         private FileDBSerializerOptions Options;
         private IFileDBDocument TargetDocument;
-        private PrimitiveTypeConverter PrimitiveConverter = new PrimitiveTypeConverter();
 
         #region Constructor
         public FileDBDocumentSerializer_OLD(FileDBSerializerOptions options)
@@ -178,7 +177,7 @@ namespace FileDBSerializing.ObjectSerializer
             }
             else if (PrimitiveObjectInstance.GetType().IsPrimitiveType())
             {
-                AttribInject.Content = PrimitiveConverter.GetBytes(PrimitiveObjectInstance);
+                AttribInject.Content = PrimitiveTypeConverter.GetBytes(PrimitiveObjectInstance);
             }
             else if (PrimitiveObjectInstance.GetType().IsPrimitiveListType())
             {
@@ -254,7 +253,7 @@ namespace FileDBSerializing.ObjectSerializer
                 for (int i = 0; i < ArrayObject.Length; i++)
                 {
                     var SingleValue = ArrayObject.GetValue(i);
-                    ContentStream.Write(PrimitiveConverter.GetBytes(SingleValue));
+                    ContentStream.Write(PrimitiveTypeConverter.GetBytes(SingleValue));
                 }
                 return ContentStream.ToArray();
             }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBSerializerOptions.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBSerializerOptions.cs
@@ -10,6 +10,7 @@ namespace FileDBSerializing.ObjectSerializer
     {
         public FileDBDocumentVersion Version { get; set; }
         public String NoneTag { get; } = "None";
+        public String ArraySizeTag { get; } = "size";
         public Encoding DefaultEncoding { get; set; } = Encoding.UTF8;
 
         public bool IgnoreMissingProperties { get; set; } = false;

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/PrimitiveTypeConverter.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/PrimitiveTypeConverter.cs
@@ -4,12 +4,8 @@ using System.Text;
 
 namespace FileDBSerializing.ObjectSerializer
 {
-    public class PrimitiveTypeConverter
+    public static class PrimitiveTypeConverter
     {
-        public PrimitiveTypeConverter()
-        {
-
-        }
         //----- ########################### -----//
         //      Make sure that the set of keys is identical in both dictionaries!!!!
         //      Else this will mess with SupportsType() and lead to fuckwhat-types of errors.
@@ -48,7 +44,7 @@ namespace FileDBSerializing.ObjectSerializer
         };
 
 
-        public byte[] GetBytes(object t)
+        public static byte[] GetBytes(object t)
         {
             Type _type = t.GetType();
             if (SupportsType(_type))
@@ -57,14 +53,14 @@ namespace FileDBSerializing.ObjectSerializer
                 throw new InvalidOperationException(_type + " is not a primitive type!");
         }
 
-        public object GetObject(Type TargetType, byte[] b)
+        public static object GetObject(Type TargetType, byte[] b)
         {
             if (!SupportsType(TargetType)) throw new InvalidOperationException($"{TargetType} is not a primitive type");
 
             return PrimitiveTypesBack[TargetType](b);
         }
 
-        public TargetType GetObject<TargetType>(byte[] b) 
+        public static TargetType GetObject<TargetType>(byte[] b) 
             => (TargetType)GetObject(typeof(TargetType), b);
 
         public static bool SupportsType(Type t)

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveArrayHandler.cs
@@ -11,11 +11,9 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 {
     public class PrimitiveArrayHandler : ISerializationHandler
     {
-        private static PrimitiveTypeConverter? PrimitiveConverter;
 
         public PrimitiveArrayHandler()
         {
-            PrimitiveConverter ??= new PrimitiveTypeConverter();
         }
 
         public IEnumerable<FileDBNode> Handle(object? item, string tagName, IFileDBDocument workingDocument, FileDBSerializerOptions options)
@@ -39,7 +37,7 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
                 {
                     var singleVal = arrayInstance.GetValue(i);
                     //can singleVal be null here? idk, may lead to errors.
-                    ContentStream.Write(PrimitiveConverter!.GetBytes(singleVal));
+                    ContentStream.Write(PrimitiveTypeConverter.GetBytes(singleVal));
                 }
                 attr.Content = ContentStream.ToArray();
             }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/PrimitiveHandler.cs
@@ -12,11 +12,9 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
     /// </summary>
     public class PrimitiveHandler : ISerializationHandler
     {
-        private static PrimitiveTypeConverter? PrimitiveConverter;
 
         public PrimitiveHandler()
         {
-            PrimitiveConverter ??= new PrimitiveTypeConverter();
         }
 
         /// <summary>
@@ -37,7 +35,7 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 
             attr.Content = item is null ?
                     new byte[0]
-                    : PrimitiveConverter!.GetBytes(item);
+                    : PrimitiveTypeConverter.GetBytes(item);
             return attr.AsEnumerable();
         }
     }

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceArrayHandler.cs
@@ -17,7 +17,7 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
                 return t.AsEnumerable();
 
             var size = arrayInstance.Length;
-            var size_node = workingDocument.AddAttrib("size");
+            var size_node = workingDocument.AddAttrib(options.ArraySizeTag);
             size_node.Content = BitConverter.GetBytes(size);
             t.AddChild(size_node);
 

--- a/src/Interpreting/ConverterFunctions.cs
+++ b/src/Interpreting/ConverterFunctions.cs
@@ -9,53 +9,52 @@ namespace FileDBReader
 {
     public static class ConverterFunctions
     {
-        private static PrimitiveTypeConverter typeConverter = new PrimitiveTypeConverter();
         #region FunctionDictionaries
         public static Dictionary<Type, Func<string, Encoding, String>> ConversionRulesImport = new Dictionary<Type, Func<string, Encoding, String>>
             {
-                { typeof(bool),   (s, Encoding) => typeConverter.GetObject<bool>(HexHelper.ToBytes(s)).ToString()},
-                { typeof(byte),   (s, Encoding) => typeConverter.GetObject<byte>(HexHelper.ToBytes(s)).ToString()},
-                { typeof(sbyte),  (s, Encoding) => typeConverter.GetObject<sbyte>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(short),  (s, Encoding) => typeConverter.GetObject<short>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(ushort), (s, Encoding) => typeConverter.GetObject<ushort>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(int),    (s, Encoding) => typeConverter.GetObject<int>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(uint),   (s, Encoding) => typeConverter.GetObject<uint>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(long),   (s, Encoding) => typeConverter.GetObject<long>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(ulong),  (s, Encoding) => typeConverter.GetObject<ulong>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(float),  (s, Encoding) => typeConverter.GetObject<float>(HexHelper.ToBytes(s)).ToString() },
-                { typeof(double), (s, Encoding) => typeConverter.GetObject<double>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(bool),   (s, Encoding) => PrimitiveTypeConverter.GetObject<bool>(HexHelper.ToBytes(s)).ToString()},
+                { typeof(byte),   (s, Encoding) => PrimitiveTypeConverter.GetObject<byte>(HexHelper.ToBytes(s)).ToString()},
+                { typeof(sbyte),  (s, Encoding) => PrimitiveTypeConverter.GetObject<sbyte>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(short),  (s, Encoding) => PrimitiveTypeConverter.GetObject<short>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(ushort), (s, Encoding) => PrimitiveTypeConverter.GetObject<ushort>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(int),    (s, Encoding) => PrimitiveTypeConverter.GetObject<int>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(uint),   (s, Encoding) => PrimitiveTypeConverter.GetObject<uint>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(long),   (s, Encoding) => PrimitiveTypeConverter.GetObject<long>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(ulong),  (s, Encoding) => PrimitiveTypeConverter.GetObject<ulong>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(float),  (s, Encoding) => PrimitiveTypeConverter.GetObject<float>(HexHelper.ToBytes(s)).ToString() },
+                { typeof(double), (s, Encoding) => PrimitiveTypeConverter.GetObject<double>(HexHelper.ToBytes(s)).ToString() },
                 { typeof(String), (s, Encoding) => ToString(s, Encoding)}
             };
 
         public static Dictionary<Type, Func<String, Encoding, byte[]>> ConversionRulesExport = new Dictionary<Type, Func<String, Encoding, byte[]>>
             {
-                { typeof(bool),     (s, Encoding)   => typeConverter.GetBytes(bool.Parse(s))},
-                { typeof(byte),     (s, Encoding)   => typeConverter.GetBytes(byte.Parse(s))},
-                { typeof(sbyte),    (s, Encoding)   => typeConverter.GetBytes(sbyte.Parse(s))},
-                { typeof(short),    (s, Encoding)   => typeConverter.GetBytes(short.Parse(s))},
-                { typeof(ushort),   (s, Encoding)   => typeConverter.GetBytes(ushort.Parse(s))},
-                { typeof(int),      (s, Encoding)   => typeConverter.GetBytes(int.Parse(s))},
-                { typeof(uint),     (s, Encoding)   => typeConverter.GetBytes(uint.Parse(s))},
-                { typeof(long),     (s, Encoding)   => typeConverter.GetBytes(long.Parse(s))},
-                { typeof(ulong),    (s, Encoding)   => typeConverter.GetBytes(ulong.Parse(s))},
-                { typeof(float),    (s, Encoding)   => typeConverter.GetBytes(float.Parse(s))},
-                { typeof(double),   (s, Encoding)   => typeConverter.GetBytes(double.Parse(s))},
+                { typeof(bool),     (s, Encoding)   => PrimitiveTypeConverter.GetBytes(bool.Parse(s))},
+                { typeof(byte),     (s, Encoding)   => PrimitiveTypeConverter.GetBytes(byte.Parse(s))},
+                { typeof(sbyte),    (s, Encoding)   => PrimitiveTypeConverter.GetBytes(sbyte.Parse(s))},
+                { typeof(short),    (s, Encoding)   => PrimitiveTypeConverter.GetBytes(short.Parse(s))},
+                { typeof(ushort),   (s, Encoding)   => PrimitiveTypeConverter.GetBytes(ushort.Parse(s))},
+                { typeof(int),      (s, Encoding)   => PrimitiveTypeConverter.GetBytes(int.Parse(s))},
+                { typeof(uint),     (s, Encoding)   => PrimitiveTypeConverter.GetBytes(uint.Parse(s))},
+                { typeof(long),     (s, Encoding)   => PrimitiveTypeConverter.GetBytes(long.Parse(s))},
+                { typeof(ulong),    (s, Encoding)   => PrimitiveTypeConverter.GetBytes(ulong.Parse(s))},
+                { typeof(float),    (s, Encoding)   => PrimitiveTypeConverter.GetBytes(float.Parse(s))},
+                { typeof(double),   (s, Encoding)   => PrimitiveTypeConverter.GetBytes(double.Parse(s))},
                 { typeof(String),   (s, Encoding)   => Encoding.GetBytes(s)}
             };
 
         public static Dictionary<Type, Func<string, object>> ConversionRulesToObject = new Dictionary<Type, Func<string, object>>
             {
-                { typeof(bool),   s => typeConverter.GetObject<bool>(HexHelper.ToBytes(s))},
-                { typeof(byte),   s => typeConverter.GetObject<byte>(HexHelper.ToBytes(s))},
-                { typeof(sbyte),  s => typeConverter.GetObject<sbyte>(HexHelper.ToBytes(s))},
-                { typeof(short),  s => typeConverter.GetObject<short>(HexHelper.ToBytes(s)) },
-                { typeof(ushort), s => typeConverter.GetObject<ushort>(HexHelper.ToBytes(s)) },
-                { typeof(int),    s => typeConverter.GetObject<int>(HexHelper.ToBytes(s))},
-                { typeof(uint),   s => typeConverter.GetObject<uint>(HexHelper.ToBytes(s))},
-                { typeof(long),   s => typeConverter.GetObject<long>(HexHelper.ToBytes(s))},
-                { typeof(ulong),  s => typeConverter.GetObject<ulong>(HexHelper.ToBytes(s))},
-                { typeof(double), s => typeConverter.GetObject<double>(HexHelper.ToBytes(s))},
-                { typeof(float),  s => typeConverter.GetObject<float>(HexHelper.ToBytes(s))},
+                { typeof(bool),   s => PrimitiveTypeConverter.GetObject<bool>(HexHelper.ToBytes(s))},
+                { typeof(byte),   s => PrimitiveTypeConverter.GetObject<byte>(HexHelper.ToBytes(s))},
+                { typeof(sbyte),  s => PrimitiveTypeConverter.GetObject<sbyte>(HexHelper.ToBytes(s))},
+                { typeof(short),  s => PrimitiveTypeConverter.GetObject<short>(HexHelper.ToBytes(s)) },
+                { typeof(ushort), s => PrimitiveTypeConverter.GetObject<ushort>(HexHelper.ToBytes(s)) },
+                { typeof(int),    s => PrimitiveTypeConverter.GetObject<int>(HexHelper.ToBytes(s))},
+                { typeof(uint),   s => PrimitiveTypeConverter.GetObject<uint>(HexHelper.ToBytes(s))},
+                { typeof(long),   s => PrimitiveTypeConverter.GetObject<long>(HexHelper.ToBytes(s))},
+                { typeof(ulong),  s => PrimitiveTypeConverter.GetObject<ulong>(HexHelper.ToBytes(s))},
+                { typeof(double), s => PrimitiveTypeConverter.GetObject<double>(HexHelper.ToBytes(s))},
+                { typeof(float),  s => PrimitiveTypeConverter.GetObject<float>(HexHelper.ToBytes(s))},
                 { typeof(String), s => ToString(s, new UnicodeEncoding())}
             };
         

--- a/unittests/FileDBReader-Tests/FileDBSerializer/FileDBLookupTests.cs
+++ b/unittests/FileDBReader-Tests/FileDBSerializer/FileDBLookupTests.cs
@@ -36,18 +36,18 @@ namespace FileDBSerializing.Tests
         public void LookUpTest_Attrib_Single()
         { 
             IFileDBDocument document = TestDataSources.BuildDocument<FileDBDocument_V2>();
-            Attrib floatattr = (Attrib)document.SelectSingleNode("TestRootOne/FloatAttrib_Child");
+            Attrib? floatattr = document.SelectSingleNode("TestRootOne/FloatAttrib_Child") as Attrib;
             var bytes = BitConverter.GetBytes(33.2f);
-            CollectionAssert.AreEquivalent(bytes, floatattr.Content);
+            CollectionAssert.AreEquivalent(bytes, floatattr?.Content);
         }
 
         [TestMethod]
         public void LookUpTest_Tag_Single()
         {
             IFileDBDocument document = TestDataSources.BuildDocument<FileDBDocument_V2>();
-            Tag Tag = (Tag)document.SelectSingleNode("TestRootOne/None");
+            Tag? Tag = document.SelectSingleNode("TestRootOne/None") as Tag;
             var TagName = "None";
-            Assert.AreEqual(TagName, Tag.GetName());
+            Assert.AreEqual(TagName, Tag?.GetName());
         }
     }
 }

--- a/unittests/FileDBReader-Tests/TestDataSources.cs
+++ b/unittests/FileDBReader-Tests/TestDataSources.cs
@@ -69,6 +69,15 @@ namespace FileDBReader_Tests
                 new Tuple<int, DeserChild, DeserChild>(6, new DeserChild(){ ID = 60 }, new DeserChild(){ID = 600}),
             };
 
+            result.FlatLongList = new List<long>() { long.MinValue, -1L, 0L, 1L, long.MaxValue };
+
+            result.FlatTupleList = new List<Tuple<int, DeserChild, DeserChild>>()
+            {
+                new Tuple<int, DeserChild, DeserChild>(7, new DeserChild(){ ID = 70 }, new DeserChild(){ID = 700}),
+                new Tuple<int, DeserChild, DeserChild>(8, new DeserChild(){ ID = 80 }, new DeserChild(){ID = 800}),
+                new Tuple<int, DeserChild, DeserChild>(9, new DeserChild(){ ID = 90 }, new DeserChild(){ID = 900}),
+            };
+
             result.EncodingAwareString = "teststring 1234";
             result.DefaultString = "Oh no you don't";
             return result;

--- a/unittests/FileDBReader-Tests/TestDataSources.cs
+++ b/unittests/FileDBReader-Tests/TestDataSources.cs
@@ -32,17 +32,43 @@ namespace FileDBReader_Tests
             result.Reference.ID = 1337;
             result.IntValue = 14;
             result.IntArray = new int[] { 1, 2, 3 };
+
             result.ReferenceArray = new DeserChild[]
                 {
                     new DeserChild() { ID = 42},
                     new DeserChild() { ID = 34 }
                 };
+
             result.ReferenceList = new List<DeserChild>()
             {
                 new DeserChild() {ID = 69},
                 new DeserChild() {ID = 420},
             };
             result.PrimitiveList = new List<short>() { (short)-1, (short)0, (short)1, short.MaxValue };
+
+            result.IndexTuple = new Tuple<int, DeserChild>(1, new DeserChild() { ID = 111 });
+
+            result.NestedTuple = new Tuple<int, Tuple<short[], string, DeserChild>>(
+                2, 
+                new Tuple<short[], string, DeserChild>(
+                    new short[] { short.MinValue, short.MaxValue }, "Hello World!", new DeserChild() { ID = 222 }
+                    )
+                );
+
+            result.ListOfTuples = new List<Tuple<int, DeserChild, DeserChild>>()
+            {
+                new Tuple<int, DeserChild, DeserChild>(1, new DeserChild(){ ID = 10 }, new DeserChild(){ID = 100}),
+                new Tuple<int, DeserChild, DeserChild>(2, new DeserChild(){ ID = 20 }, new DeserChild(){ID = 200}),
+                new Tuple<int, DeserChild, DeserChild>(3, new DeserChild(){ ID = 30 }, new DeserChild(){ID = 300}),
+            };
+
+            result.ArrayOfTuples = new Tuple<int, DeserChild, DeserChild>[]
+            {
+                new Tuple<int, DeserChild, DeserChild>(4, new DeserChild(){ ID = 40 }, new DeserChild(){ID = 400}),
+                new Tuple<int, DeserChild, DeserChild>(5, new DeserChild(){ ID = 50 }, new DeserChild(){ID = 500}),
+                new Tuple<int, DeserChild, DeserChild>(6, new DeserChild(){ ID = 60 }, new DeserChild(){ID = 600}),
+            };
+
             result.EncodingAwareString = "teststring 1234";
             result.DefaultString = "Oh no you don't";
             return result;

--- a/unittests/FileDBReader-Tests/TestDataSources.cs
+++ b/unittests/FileDBReader-Tests/TestDataSources.cs
@@ -37,6 +37,12 @@ namespace FileDBReader_Tests
                     new DeserChild() { ID = 42},
                     new DeserChild() { ID = 34 }
                 };
+            result.ReferenceList = new List<DeserChild>()
+            {
+                new DeserChild() {ID = 69},
+                new DeserChild() {ID = 420},
+            };
+            result.PrimitiveList = new List<short>() { (short)-1, (short)0, (short)1, short.MaxValue };
             result.EncodingAwareString = "teststring 1234";
             result.DefaultString = "Oh no you don't";
             return result;

--- a/unittests/FileDBReader-Tests/TestSerializationData/DeserObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/DeserObject.cs
@@ -16,6 +16,12 @@ namespace FileDBReader_Tests.TestSerializationData
         public List<DeserChild> ReferenceList { get; set; }
         public List<short> PrimitiveList { get; set; }
 
+        public Tuple<int, DeserChild> IndexTuple { get; set; }
+        public Tuple<int, Tuple<short[], string, DeserChild>> NestedTuple { get; set; }
+
+        public List<Tuple<int, DeserChild, DeserChild>> ListOfTuples { get; set; }
+        public Tuple<int, DeserChild, DeserChild>[] ArrayOfTuples { get; set; }
+
         public UnicodeString EncodingAwareString { get; set; }
         public String DefaultString { get; set; }
     }

--- a/unittests/FileDBReader-Tests/TestSerializationData/DeserObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/DeserObject.cs
@@ -13,6 +13,8 @@ namespace FileDBReader_Tests.TestSerializationData
         public DeserChild? Reference { get; set; }
         public int[] IntArray { get; set; }
         public DeserChild[] ReferenceArray { get; set; }
+        public List<DeserChild> ReferenceList { get; set; }
+        public List<short> PrimitiveList { get; set; }
 
         public UnicodeString EncodingAwareString { get; set; }
         public String DefaultString { get; set; }

--- a/unittests/FileDBReader-Tests/TestSerializationData/DeserObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/DeserObject.cs
@@ -1,4 +1,5 @@
 ﻿using FileDBSerializing.EncodingAwareStrings;
+using FileDBSerializing.ObjectSerializer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +22,11 @@ namespace FileDBReader_Tests.TestSerializationData
 
         public List<Tuple<int, DeserChild, DeserChild>> ListOfTuples { get; set; }
         public Tuple<int, DeserChild, DeserChild>[] ArrayOfTuples { get; set; }
+
+        [FlatArray]
+        public List<long> FlatLongList { get; set; }
+        [FlatArray]
+        public List<Tuple<int, DeserChild, DeserChild>> FlatTupleList { get; set; }
 
         public UnicodeString EncodingAwareString { get; set; }
         public String DefaultString { get; set; }


### PR DESCRIPTION
The first 3 commits are some design fixes, which later affected the Deserializer Implementations as I wrote them.

ReferenceArray Deserialization Handler now checks that the Tag given to it contains a `<size>` tag, and that the `<size>` tag is in first position. It also checks that the count of the remaining children after the `<size>` tag is equal to the value inside the `<size>` tag. It then iterates over the remaining children and calls their respective handler to create the resulting array.
In case of the item type being a Tuple, it also unpacks the Tuple-Wrapping tags, and feeds their content to the Tuple handler.

ListHandler iterates over its children and adds them to a newly created List object (that gets created via reflection from the target type). Special Case: The List handler correctly strides over Tuple-Typed content, to correctly feed the Tuple handler the correct amount of items.

TupleHandler takes a Collection of FileDBNodes and constructs a tuple from them. It correctly unpacks nested Tuples that are surrounded by an extra tag.

FlatArrayHandler is effectively just a ListHandler except that it does not get a tag with the List items in it, but instead gets the Collection of List items directly.

The Test Class for the Unit Test "NewDeserializerTest" has been extended to test all above cases.