### PR TITLE
Add Feature: Inherited Property Order Management

### DIFF
--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBDocumentSerializer.cs
@@ -25,7 +25,7 @@ namespace FileDBSerializing.ObjectSerializer
         //serializes an object into a filedb document
         public IFileDBDocument WriteObjectStructureToFileDBDocument(object graph)
         {
-            PropertyInfo[] properties = graph.GetType().GetProperties();
+            IEnumerable<PropertyInfo> properties = graph.GetType().GetPropertiesWithOrder();
             TargetDocument.Roots = SerializePropertyCollection(properties, graph).ToList();
 
             var tmpdocument = TargetDocument;

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/PropertyLocationAttribute.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/PropertyLocationAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileDBSerializer.ObjectSerializer
+{
+    /// <summary>
+    /// PropertyLocationAttribute can be added to a Class to inform that its Properties should be serialized in a specific location in relation to its base class.
+    /// It can also be added to a Property to locate that specific property related to the base class' properties during serialization.
+    /// When adding the Attribute to both class and property, the attribute on the property will take precedence.
+    /// This Attribute has no effect if the targetet class (or class of the respective property) has no base class other than object.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public class PropertyLocationAttribute : Attribute
+    {
+        public PropertyLocationAttribute(PropertyLocationOption location)
+        {
+            Location = location;
+        }
+
+        public PropertyLocationOption Location { get; }
+    }
+
+    public enum PropertyLocationOption
+    {
+        BEFORE_PARENT,
+        AFTER_PARENT
+    }
+}

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceTypeHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceTypeHandler.cs
@@ -19,7 +19,7 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
 
             if (item is null) return t.AsEnumerable();
 
-            PropertyInfo[] properties = item.GetType().GetProperties();
+            IEnumerable<PropertyInfo> properties = item.GetType().GetPropertiesWithOrder();
 
             foreach (var _prop in properties)
             {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/TypeExtensions.cs
@@ -84,7 +84,9 @@ namespace FileDBSerializing.ObjectSerializer
             }
 
             var currentProperties = type.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public);
-            foreach(PropertyInfo info in currentProperties)
+            var orderedProperties = currentProperties.OrderBy(x => x.MetadataToken);
+
+            foreach(PropertyInfo info in orderedProperties)
             {
                 if(info.GetCustomAttribute<PropertyLocationAttribute>() is PropertyLocationAttribute propertyAttribute && propertyAttribute is not null)
                 {

--- a/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/AfterObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/AfterObject.cs
@@ -1,0 +1,13 @@
+﻿using FileDBSerializer.ObjectSerializer;
+using FileDBSerializing.Tests.TestData;
+using System.Collections.Generic;
+
+namespace FileDBReader_Tests.TestSerializationData.PropertyOrder
+{
+    [PropertyLocation(PropertyLocationOption.AFTER_PARENT)]
+    public class AfterObject : BaseObject
+    {
+        public long? AfterID { get; set; }
+        public List<ChildElement>? AfterList { get; set; }
+    }
+}

--- a/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/BaseObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/BaseObject.cs
@@ -1,0 +1,10 @@
+﻿using FileDBSerializing.Tests.TestData;
+
+namespace FileDBReader_Tests.TestSerializationData.PropertyOrder
+{
+    public class BaseObject
+    {
+        public int? BaseCount { get; set; }
+        public ChildElement? BaseChild { get; set; }
+    }
+}

--- a/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/BeforeObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/BeforeObject.cs
@@ -1,0 +1,13 @@
+﻿using FileDBSerializer.ObjectSerializer;
+using FileDBSerializing.Tests.TestData;
+using System.Collections.Generic;
+
+namespace FileDBReader_Tests.TestSerializationData.PropertyOrder
+{
+    [PropertyLocation(PropertyLocationOption.BEFORE_PARENT)]
+    public class BeforeObject : BaseObject
+    {
+        public long? BeforeID { get; set; }
+        public List<ChildElement>? BeforeList { get; set; }
+    }
+}

--- a/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/MixedObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/MixedObject.cs
@@ -1,0 +1,15 @@
+﻿using FileDBSerializer.ObjectSerializer;
+using FileDBSerializing.Tests.TestData;
+using System.Collections.Generic;
+
+namespace FileDBReader_Tests.TestSerializationData.PropertyOrder
+{
+    public class MixedObject : BaseObject
+    {
+        [PropertyLocation(PropertyLocationOption.BEFORE_PARENT)]
+        public long? FirstID { get; set; }
+        [PropertyLocation(PropertyLocationOption.AFTER_PARENT)]
+        public List<ChildElement>? EndList { get; set; }
+        public int[]? SecondIntArr { get; set; } //Default to Before, but is after FirstID in this class
+    }
+}

--- a/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/ParentObject.cs
+++ b/unittests/FileDBReader-Tests/TestSerializationData/PropertyOrder/ParentObject.cs
@@ -1,0 +1,9 @@
+﻿namespace FileDBReader_Tests.TestSerializationData.PropertyOrder
+{
+    public class ParentObject
+    {
+        public BeforeObject? Before { get; set; }
+        public AfterObject? After { get; set; }
+        public MixedObject? Mixed { get; set; }
+    }
+}


### PR DESCRIPTION
By default in C#, inherited properties (properties in the Base class) are returned AFTER the child classes' properties. This behaviour may not be intended during deserialization and until now could only be controlled by avoiding using a base class and duplicating all the properties.

This feature instead adds the PropertyLocationAttribute which can be added to both classes and single properties and controls how the annotated (classes') properties are located in reference to their base class' properties.

The default behaviour is set to add the child classes' properties before their base class' properties as to mirror default C# behaviour.

Corresponding Unit Tests have been added and are named:
- TestPropertyOrderAfter
- TestPropertyOrderBefore
- TestPropertyOrderMixed
- TestPropertyOrderNested