### PR TITLE
Empty ReferenceArrays export without size tag

### DIFF
--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ReferenceArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ReferenceArrayHandler.cs
@@ -22,10 +22,17 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
             var actualTargetType = targetType.GetNullableType();
             var arrayContentType = actualTargetType.GetElementType()!;
 
+            //Empty Reference Array does not need a <size></size> tag/attrib
             if(tag.Children.Count == 0)
             {
                 var emptyInstance = Array.CreateInstance(arrayContentType, 0);
                 return emptyInstance;
+            }
+            else if(tag.Children.Count == 1)
+            {
+                throw new InvalidOperationException($"The tag that should be parsed as a reference array has exactly one child. " +
+                    $"This is not possible as it should either have 0 children (when empty), " +
+                    $"or should have at least 2 children (1+ child items plus the size tag).");
             }
 
             var elemCountEntry = tag.SelectSingleNode(options.ArraySizeTag);

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBSerializerOptions.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/FileDBSerializerOptions.cs
@@ -18,7 +18,7 @@ namespace FileDBSerializing.ObjectSerializer
         public bool SkipDefaultedValues { get; set; } = false;
         public bool SkipSimpleNullValues { get; set; } = true;
         public bool SkipListNullValues { get; set; } = true;
-        public bool SkipReferenceArrayNullValues { get; set; } = false;
+        public bool SkipReferenceArrayNullValues { get; set; } = true;
 
         public FileDBSerializerOptions()
         {

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceArrayHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/SerializationHandlers/ReferenceArrayHandler.cs
@@ -21,6 +21,11 @@ namespace FileDBSerializer.ObjectSerializer.SerializationHandlers
                 return t.AsEnumerable();
 
             var size = arrayInstance.Length;
+
+            //Empty Reference Array does not need a <size></size> tag/attrib
+            if (size == 0)
+                return t.AsEnumerable();
+
             var size_node = workingDocument.AddAttrib(options.ArraySizeTag);
             size_node.Content = BitConverter.GetBytes(size);
             t.AddChild(size_node);


### PR DESCRIPTION
Empty Reference arrays should export without size tag (eg. AnimalHandler->HerdAreas->None->DangerPoints). The deserializer already accepts empty/self-closing tags as Reference Arrays, but currently empty Reference Arrays export with a <size> tag.

This used to be intended behaviour to allow Reference Arrays with a <size>0</size> tag, and the empty array would be done with a null ReferenceArray and a corresponding FileDBSerializerOption, but that leads to the effect that there is a discrepancy when deserializing data and directly serializing it again.

This change makes it so that a ReferenceArray tag with <size>0</size> can never be exported, and reading a ReferenceArray with only 1 child in the tag throws an error.

A UnitTest to confirm that an error is thrown when deserializing a ReferenceArray with exactly 1 child tag was added (ErrorOnInvalidReferenceArray). The SkipSimpleNullValues UnitTest was adapted to match the new default behaviour.

An additional UnitTest was added to ensure that deserializing and then serializing an empty ReferenceArray keeps the xml document the same.

Also, a mistake with the FileDBDocumentDeserializer was resolved, as its top layer handler should act like the ReferenceTypeHandler does (iterate over the FileDBNodes), but it acted differently (iterated over target type properties).