### PR TITLE
Improve Error Message for missing Properties and make RenamedPropertyHelper Thread Safe

### DIFF
--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ReferenceTypeHandler.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/DeserializationHandlers/ReferenceTypeHandler.cs
@@ -27,7 +27,7 @@ namespace FileDBSerializer.ObjectSerializer.DeserializationHandlers
                 //find the property corresponding to the child
                 var propertyinfo = targetType.GetPropertyWithRenaming(name);
                 if (propertyinfo is null && !options.IgnoreMissingProperties)
-                    throw new InvalidProgramException($"{name} could not be resolved to a property of {targetType.Name}");
+                    throw new InvalidProgramException($"{name} could not be resolved to a property of {targetType.Name} in node {tag.Name}");
                 else if (propertyinfo is null)
                     continue;
 

--- a/FileDBSerializer/FileDBSerializer/ObjectSerializer/RenamedPropertyHelper.cs
+++ b/FileDBSerializer/FileDBSerializer/ObjectSerializer/RenamedPropertyHelper.cs
@@ -1,5 +1,6 @@
 ﻿using FileDBSerializing.ObjectSerializer;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,7 +9,7 @@ namespace FileDBSerializer.ObjectSerializer
 {
     public class RenamedPropertyHelper
     {
-        private Dictionary<Type, bool> _verifiedCache;
+        private ConcurrentDictionary<Type, bool> _verifiedCache;
 
         public RenamedPropertyHelper()
         {
@@ -33,7 +34,7 @@ namespace FileDBSerializer.ObjectSerializer
                     valid = false;
                 PropertyNamesSoFar.Add(name);
             }
-            _verifiedCache.Add(t, valid);
+            _verifiedCache.TryAdd(t, valid);
             return valid;
         }
 


### PR DESCRIPTION
When writing models, I had issues finding WHERE the missing Properties where actually missing (in what node, not what type), so I improved the message in the relevant Exception.

I had a race condition when parsing multiple gamedata files in parallel, they tried adding identical Dictionary entries in the RenamedPropertyHelper Cache simultaneously. I changed that dictionary to a ConcurrentDictionary to prevent that issue.