### PR TITLE
Make sure empty attribs are recognized as such

### DIFF
--- a/src/XmlRepresentation/XmlFileDbConverter.cs
+++ b/src/XmlRepresentation/XmlFileDbConverter.cs
@@ -51,10 +51,11 @@ namespace FileDBReader.src.XmlRepresentation
             return filedb;
         }
 
-        private FileDBNode XmlNodeToFileDBNode( XmlNode n, Tag parent)
+        private FileDBNode XmlNodeToFileDBNode(XmlNode n, Tag parent)
         {
             //This is the closest we can determine this shit.
-            if ((n.FirstChild != null && n.FirstChild.NodeType == XmlNodeType.Text))
+            if ((n.FirstChild != null && n.FirstChild.NodeType == XmlNodeType.Text) || 
+                (n is XmlElement elem && elem.FirstChild == null && elem.IsEmpty == false))
                 return XmlNodeToAttrib(n, parent);
             else
                 return XmlNodeToTag(n, parent);


### PR DESCRIPTION
When turning an string or file to an XmlDocument, empty, non-selfclosing tags may have no children, but are an XmlElement that has the property IsEmpty set to false (would be true on self-closing elements). This scenario was previously not respected, making empty attribs be read as Tags and then causing deserialization to fail.

Added unit test "DeSerializeEmptyPrimitiveArray" to verify result.