### PR TITLE
bump .net to 6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.x
         
     - name: Restore dependencies
       run: dotnet restore

--- a/FileDBReader.csproj
+++ b/FileDBReader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject>FileDBReader.CommandLineHandler</StartupObject>
     <Platforms>AnyCPU;x64</Platforms>
     <Version>2.0.5</Version>

--- a/FileDBSerializer/FileDBSerializer/FileDBSerializer.csproj
+++ b/FileDBSerializer/FileDBSerializer/FileDBSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>x64</Platforms>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Anno-1800-$(AssemblyName)</PackageId>

--- a/unittests/FileDBReader-Tests/FileDBReader.Unit-Tests.csproj
+++ b/unittests/FileDBReader-Tests/FileDBReader.Unit-Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>FileDBReader_Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
.NET 5 is out of support and has been removed from GitHub actions for example.