### PR TITLE
Add o option for fc files

### DIFF
--- a/CommandLineHandler.cs
+++ b/CommandLineHandler.cs
@@ -78,6 +78,10 @@ namespace FileDBReader {
 
             [Option('z', "replace_Names", Required = false, HelpText = "String Tuples of names that should be replaced")]
             public IEnumerable<String> ReplaceOperations { get; set; }
+
+            [Option('o', "outputFileExtension", Required = false, HelpText = OUTPUT_FILEFORMAT_HELP)]
+            public String OutputFileExtension { get; set; }
+
         }
 
         [Verb("toHex", HelpText = REINTERPRET_EXPL)]
@@ -94,6 +98,7 @@ namespace FileDBReader {
 
             [Option('z', "replace_Names", Required = false, HelpText = "String Tuples of names that should be replaced")]
             public IEnumerable<String> ReplaceOperations { get; set; }
+
         }
 
         [Verb("check_fileversion", HelpText = VERSION_EXPL)]
@@ -115,6 +120,7 @@ namespace FileDBReader {
 
             [Option('y', "overwrite", Required = false, Default = false)]
             public bool overwrite { get; set; }
+
         }
 
         [Verb("hextofc", HelpText = "Reverse operation of fctohex.")]
@@ -129,6 +135,10 @@ namespace FileDBReader {
 
             [Option('y', "overwrite", Required = false, Default = false)]
             public bool overwrite { get; set; }
+
+            [Option('o', "outputFileExtension", Required = false, HelpText = OUTPUT_FILEFORMAT_HELP)]
+            public String OutputFileExtension { get; set; }
+
         }
         #endregion
 
@@ -183,7 +193,7 @@ namespace FileDBReader {
                 //OPTIONS FOR FC FILE EXPORT
                 (FcExportOptions o) =>
                 {
-                    return Functions.FcFileExport(o.InputFiles, o.Interpreter, o.overwrite);
+                    return Functions.FcFileExport(o.InputFiles, o.Interpreter, o.overwrite, o.OutputFileExtension);
                 },
                 e => 1
             ) ;

--- a/src/ToolFunctions.cs
+++ b/src/ToolFunctions.cs
@@ -12,10 +12,9 @@ namespace FileDBReader.src
     {
         //file formats and names
         private static readonly String DefaultFileFormat = "filedb";
+        private static readonly String DefaultFcFileFormat = "fc";
         private static readonly String InterpretedFileSuffix = "_interpreted";
         private static readonly String ReinterpretedFileSuffix = "_exported";
-        private static readonly String FcImportedFileSuffix = "_fcimport";
-        private static readonly String FcExportedFileSuffix = "_fcexport";
 
         //error message
         private static readonly String IOErrorMessage = "File Path wrong, File in use or does not exist.";
@@ -329,9 +328,11 @@ namespace FileDBReader.src
         #endregion
 
         #region FcExport
-        public int FcFileExport(IEnumerable<String> InputFiles, String InterpreterPath, bool overwrite)
+        public int FcFileExport(IEnumerable<String> InputFiles, String InterpreterPath, bool overwrite, String OutputFileExtension)
         {
             int returncode = 0;
+
+            var ext = OutputFileExtension ?? DefaultFcFileFormat;
 
             //Preload Interpreter
             Interpreter? Interpr = !String.IsNullOrEmpty(InterpreterPath) ?
@@ -340,16 +341,16 @@ namespace FileDBReader.src
 
             foreach (String s in InputFiles)
             {
-                FcFileExport(s, Interpr, overwrite);
+                FcFileExport(s, Interpr, overwrite, ext);
             }
             return returncode;
         }
 
-        private void FcFileExport(String InputFile, Interpreter? Interpr, bool overwrite)
+        private void FcFileExport(String InputFile, Interpreter? Interpr, bool overwrite, String OutputFileExtension)
         {
             try
             {
-                var path = Path.ChangeExtension(Path.GetFileNameWithoutExtension(InputFile), "fc");
+                var path = Path.ChangeExtension(Path.GetFileNameWithoutExtension(InputFile), OutputFileExtension);
 
                 using (Stream input = SecureIoHandler.ReadHandle(InputFile))
                 using (var output = SecureIoHandler.WriteHandle(path, overwrite))


### PR DESCRIPTION
`-o` does not really make sense for all commands, since most of the time the tool generates pure xml - but for hextofc it is definitly missing. 

closes #36 
